### PR TITLE
feat!: migrate to Effect v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@
 
 - multiple nested tree-like progress bars
 - spinner support for “we have no idea how long this takes” work
-- keep using `Console.log` / `Effect.logInfo` while progress rendering is active
+- keep using Effect v4 `Effect.log*` / `Logger` and `Console.log` while progress rendering is active
 - familiar `.all` and `.forEach` APIs — swap `Effect` for `Progress`, get progress bars basically for free
 - flicker-free rendering with [Ink](https://github.com/vadimdemedes/ink)
 
 ## Install
 
 ```bash
-bun add effective-progress
+bun add effective-progress effect@^4.0.0-beta.100
 ```
 
 ## Usage
@@ -32,14 +32,14 @@ bun add effective-progress
 Iterate items with a single progress bar.
 
 ```ts
-import { Console, Effect } from "effect";
+import { Effect } from "effect";
 import * as Progress from "effective-progress";
 
 const program = Progress.all(
   Array.from({ length: 5 }).map((_, i) =>
     Effect.gen(function* () {
       yield* Effect.sleep("1 second");
-      yield* Console.log(`Completed task ${i + 1}`);
+      yield* Effect.logInfo(`Completed task ${i + 1}`);
     }),
   ),
   { description: "Running tasks in parallel", concurrency: 2 },
@@ -75,16 +75,16 @@ Effect.runPromise(program);
 
 <img alt="Nested example output" src="docs/images/nesting.gif" width="600" />
 
-### Effect.all modes
+### Effect.all result mode
 
-Support for `either`/`validate` modes of `Effect.all` and render the amount of successes/failures.
+`Progress.all` mirrors Effect v4's fail-fast default and `mode: "result"`, rendering the amount of successes and failures as work completes.
 
 <img alt="Mixed outcomes modes output" src="docs/images/mixedOutcomes.gif" width="600" />
 
 - `Progress.all` in default mode (`mode: "default"`) remains fail-fast.
 - In fail-fast runs, unresolved units remain unprocessed.
-- `mode: "either"` and `mode: "validate"` run all effects and keep mixed outcomes in the task counters.
-- Mixed outcomes can finalize as `done` when all units are accounted for.
+- `mode: "result"` runs every effect and returns a `Result` for each outcome while keeping mixed outcomes in the task counters.
+- Result-mode tasks finalize as `done` when all units are accounted for.
 - Empty collections are valid inputs for `Progress.all` / `Progress.forEach` and render as `0/0` instead of failing.
 
 ### Single task with a typed handle
@@ -92,13 +92,13 @@ Support for `either`/`validate` modes of `Effect.all` and render the amount of s
 Use `Progress.task(...)` when you want one progress bar around a custom effect. The callback form gives you a task-local handle, so you can update counts, descriptions, and metadata without fetching the current task ID first.
 
 ```ts
-import { Console, Effect } from "effect";
+import { Effect } from "effect";
 import * as Progress from "effective-progress";
 
 const program = Progress.task(
   (task) =>
     Effect.gen(function* () {
-      yield* Console.log("Starting deployment");
+      yield* Effect.logInfo("Starting deployment");
       yield* task.incrementSucceeded();
       yield* task.update({
         description: "Uploading release bundle",
@@ -125,7 +125,7 @@ Effect.runPromise(program);
 - `examples/advancedExample.ts` - mixed high-level and low-level Progress service usage
 - `examples/basic.ts` - minimal `Progress.all` usage
 - `examples/nesting.ts` - nested tree rendering with parent and child tasks
-- `examples/mixedOutcomes.ts` - fail-fast vs `either`/`validate` with mixed success/failure counters
+- `examples/mixedOutcomes.ts` - fail-fast vs `result` mode with mixed success/failure counters
 - `examples/cliProgressSemantics.ts` - zero totals, negative totals clearing to unknown totals, overflow counts, and empty `all` / `forEach`
 - `examples/unknownTotalCounting.ts` - count successes/failures without a known total and render `processed/?`
 - `examples/typedMetadata.ts` - typed task metadata rendered through custom columns
@@ -138,11 +138,21 @@ Effect.runPromise(program);
 
 ## Configuration
 
-### Console behavior
+### Logging behavior
 
 - The Ink renderer runs with `patchConsole: true`, so console output is patched by Ink while the app is mounted.
-- `Progress.task`, `Progress.all`, and `Progress.forEach` write through the currently provided Effect `Console` implementation.
-- Formatting is controlled by the API consumer's logger/console implementation.
+- `Effect.log*` uses the active Effect v4 `Logger` set, including custom loggers installed with `Logger.layer(...)`.
+- The low-level `progress.log(...)` method emits through `Effect.log`, so it honors the current log level, logger set, annotations, and spans.
+- Direct `Console` calls still use the currently provided Effect `Console` reference.
+- Formatting and routing remain controlled by the consumer's logger and console configuration.
+
+For example, install the v4 pretty console logger around a program with:
+
+```ts
+import { Effect, Logger } from "effect";
+
+Effect.runPromise(program.pipe(Effect.provide(Logger.layer([Logger.consolePretty()]))));
+```
 
 ### Ink renderer behavior
 
@@ -177,17 +187,19 @@ The handle exposes:
 
 When you need lower-level control, the `Progress` service is available inside the effect and exposes APIs like `addTask`, `updateTask`, `incrementSucceeded(taskId, amount)`, and `completeTask(taskId)`.
 
+The primary v4-style service layers are exposed as `Progress.layer` and `ProgressStdio.layer`.
+
 Example using the lower-level service API:
 
 ```ts
-import { Console, Effect } from "effect";
+import { Effect } from "effect";
 import * as Progress from "effective-progress";
 
 const program = Progress.task(
   Effect.gen(function* () {
     const progress = yield* Progress.Progress;
     const currentTask = yield* Progress.Task;
-    yield* Console.log("This log is handled by the outer Console", { taskId: currentTask });
+    yield* Effect.logInfo("Updating the current task", { taskId: currentTask });
 
     // Manual determinate updates:
     yield* progress.incrementSucceeded(currentTask, 3);
@@ -258,6 +270,6 @@ const program = Progress.task(
 
 If a task does not provide `columns`, the renderer falls back to `Progress.Columns.defaults()`.
 
-## Notes
+## Effect compatibility
 
-- As Effect 4.0 is around the corner with some changes to logging, there may be some adjustments needed to align with the new Effect APIs.
+This release targets Effect `4.0.0-beta.100` or newer compatible v4 prereleases. Effect v4 is still in beta, so its APIs may change between beta releases.

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@effect/language-service": "^0.73.1",
         "@types/bun": "latest",
         "@types/react": "^19.2.14",
-        "effect": "^3.19.17",
+        "effect": "^4.0.0-beta.100",
         "knip": "^5.86.0",
         "oxfmt": "^0.32.0",
         "oxlint": "^1.47.0",
@@ -23,7 +23,7 @@
         "typescript": "^5",
       },
       "peerDependencies": {
-        "effect": "^3.19.17",
+        "effect": "^4.0.0-beta.100",
       },
     },
   },
@@ -55,6 +55,18 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
@@ -264,9 +276,11 @@
 
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "dts-resolver": ["dts-resolver@2.1.3", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw=="],
 
-    "effect": ["effect@3.19.17", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-MChgn9z0y3KJ2DJ+VsZt1bdVDJ0bDIZt9zm4s3iPpRLzgcEGDOIP8pwADjAWifaP0S672nlRE5rZPBbyDcjn1g=="],
+    "effect": ["effect@4.0.0-beta.100", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-K4ed+BS3HyE+NoAZ8pJss2DpuK41mb856IO7ZlPfnwBXbq8oTtAAurrsVnwe2hzPamIuaZp/Pq4/xp9qORYv8Q=="],
 
     "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
 
@@ -278,7 +292,7 @@
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
-    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -294,6 +308,8 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
+
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
@@ -307,6 +323,8 @@
     "import-without-cache": ["import-without-cache@0.2.5", "", {}, "sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A=="],
 
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
 
     "ink": ["ink@7.0.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.3.0", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.3", "auto-bind": "^5.0.1", "chalk": "^5.6.2", "cli-boxes": "^4.0.1", "cli-cursor": "^4.0.0", "cli-truncate": "^6.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.45.1", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^9.0.0", "stack-utils": "^2.0.6", "string-width": "^8.2.0", "terminal-size": "^4.0.1", "type-fest": "^5.5.0", "widest-line": "^6.0.0", "wrap-ansi": "^10.0.0", "ws": "^8.20.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.2.0", "react": ">=19.2.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-o6LAC268PLawlGVYrXTyaTfke4VtJftEheuwbgkQf7yvSXyWp1nRwBbAyKEkWXFZZsW/la5wrMuNbuBvZK2C1w=="],
 
@@ -326,6 +344,8 @@
 
     "knip": ["knip@5.86.0", "", { "dependencies": { "@nodelib/fs.walk": "^1.2.3", "fast-glob": "^3.3.3", "formatly": "^0.3.0", "jiti": "^2.6.0", "minimist": "^1.2.8", "oxc-resolver": "^11.19.1", "picocolors": "^1.1.1", "picomatch": "^4.0.1", "smol-toml": "^1.5.2", "strip-json-comments": "5.0.3", "unbash": "^2.2.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "peerDependencies": { "@types/node": ">=18", "typescript": ">=5.0.4 <7" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-tGpRCbP+L+VysXnAp1bHTLQ0k/SdC3M3oX18+Cpiqax1qdS25iuCPzpK8LVmAKARZv0Ijri81Wq09Rzk0JTl+Q=="],
 
+    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
@@ -333,6 +353,14 @@
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "msgpackr": ["msgpackr@2.0.4", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
+    "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
@@ -352,7 +380,7 @@
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
-    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
@@ -404,6 +432,8 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
+
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
     "tsdown": ["tsdown@0.21.0-beta.2", "", { "dependencies": { "ansis": "^4.2.0", "cac": "^6.7.14", "defu": "^6.1.4", "empathic": "^2.0.0", "hookable": "^6.0.1", "import-without-cache": "^0.2.5", "obug": "^2.1.1", "picomatch": "^4.0.3", "rolldown": "1.0.0-rc.5", "rolldown-plugin-dts": "^0.22.1", "semver": "^7.7.4", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0", "unrun": "^0.2.28" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@vitejs/devtools": "*", "publint": "^0.3.0", "typescript": "^5.0.0", "unplugin-lightningcss": "^0.4.0", "unplugin-unused": "^0.5.0" }, "optionalPeers": ["@arethetypeswrong/core", "@vitejs/devtools", "publint", "typescript", "unplugin-lightningcss", "unplugin-unused"], "bin": { "tsdown": "dist/run.mjs" } }, "sha512-OKj8mKf0ws1ucxuEi3mO/OGyfRQxO9MY2D6SoIE/7RZcbojsZSBhJr4xC4MNivMqrQvi3Ke2e+aRZDemPBWPCw=="],
@@ -422,6 +452,8 @@
 
     "unrun": ["unrun@0.2.28", "", { "dependencies": { "rolldown": "1.0.0-rc.5" }, "peerDependencies": { "synckit": "^0.11.11" }, "optionalPeers": ["synckit"], "bin": { "unrun": "dist/cli.mjs" } }, "sha512-LqMrI3ZEUMZ2476aCsbUTfy95CHByqez05nju4AQv4XFPkxh5yai7Di1/Qb0FoELHEEPDWhQi23EJeFyrBV0Og=="],
 
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
     "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
@@ -430,11 +462,13 @@
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
-    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "knip/yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
   }

--- a/examples/mixedNestedColumns.ts
+++ b/examples/mixedNestedColumns.ts
@@ -211,4 +211,4 @@ const program = Progress.task(
   },
 );
 
-Effect.runPromise(program.pipe(Effect.provide(Logger.pretty)));
+Effect.runPromise(program.pipe(Effect.provide(Logger.layer([Logger.consolePretty()]))));

--- a/examples/mixedOutcomes.ts
+++ b/examples/mixedOutcomes.ts
@@ -4,7 +4,7 @@ import * as Progress from "../src";
 const makeMixedEffects = () => [
   Effect.sleep("1 second").pipe(Effect.as("alpha")),
   Effect.sleep("1.2 seconds").pipe(Effect.as("beta")),
-  Effect.sleep("900 millis").pipe(Effect.zipRight(Effect.fail("boom"))),
+  Effect.sleep("900 millis").pipe(Effect.andThen(Effect.fail("boom"))),
   Effect.sleep("1.1 seconds").pipe(Effect.as("gamma")),
 ];
 
@@ -15,9 +15,9 @@ const makeSuccessEffects = () => [
 ];
 
 const makeAllFailedEffects = () => [
-  Effect.sleep("700 millis").pipe(Effect.zipRight(Effect.fail("err-1"))),
-  Effect.sleep("900 millis").pipe(Effect.zipRight(Effect.fail("err-2"))),
-  Effect.sleep("1 second").pipe(Effect.zipRight(Effect.fail("err-3"))),
+  Effect.sleep("700 millis").pipe(Effect.andThen(Effect.fail("err-1"))),
+  Effect.sleep("900 millis").pipe(Effect.andThen(Effect.fail("err-2"))),
+  Effect.sleep("1 second").pipe(Effect.andThen(Effect.fail("err-3"))),
 ];
 
 const program = Effect.gen(function* () {
@@ -30,32 +30,22 @@ const program = Effect.gen(function* () {
   );
 
   yield* Progress.all(makeMixedEffects(), {
-    description: "either mode (collect all outcomes)",
-    mode: "either",
+    description: "result mode (collect all outcomes)",
+    mode: "result",
     concurrency: 2,
   });
-
-  yield* Effect.exit(
-    Progress.all(makeMixedEffects(), {
-      description: "validate mode (collect failures)",
-      mode: "validate",
-      concurrency: 2,
-    }),
-  );
 
   yield* Progress.all(makeSuccessEffects(), {
-    description: "either mode (all succeeded)",
-    mode: "either",
+    description: "result mode (all succeeded)",
+    mode: "result",
     concurrency: 2,
   });
 
-  yield* Effect.exit(
-    Progress.all(makeAllFailedEffects(), {
-      description: "validate mode (all failed)",
-      mode: "validate",
-      concurrency: 2,
-    }),
-  );
+  yield* Progress.all(makeAllFailedEffects(), {
+    description: "result mode (all failed)",
+    mode: "result",
+    concurrency: 2,
+  });
 
   const progress = yield* Progress.Progress;
   const taskId = yield* progress.addTask({

--- a/examples/showcase.ts
+++ b/examples/showcase.ts
@@ -80,4 +80,4 @@ const program = Effect.gen(function* () {
   );
 }).pipe(Progress.task({ description: "Showcase program", transient: false }));
 
-Effect.runPromise(program.pipe(Effect.provide(Logger.pretty)));
+Effect.runPromise(program.pipe(Effect.provide(Logger.layer([Logger.consolePretty()]))));

--- a/examples/simpleExample.ts
+++ b/examples/simpleExample.ts
@@ -56,4 +56,4 @@ const program = Effect.gen(function* () {
   yield* Console.log("All advanced progress examples finished.");
 });
 
-Effect.runPromise(program.pipe(Effect.provide(Logger.pretty)));
+Effect.runPromise(program.pipe(Effect.provide(Logger.layer([Logger.consolePretty()]))));

--- a/examples/typedMetadata.ts
+++ b/examples/typedMetadata.ts
@@ -107,4 +107,4 @@ const program = Effect.gen(function* () {
   yield* Effect.logInfo("Evaluation complete");
 });
 
-Effect.runPromise(program.pipe(Effect.provide(Logger.pretty)));
+Effect.runPromise(program.pipe(Effect.provide(Logger.layer([Logger.consolePretty()]))));

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@effect/language-service": "^0.73.1",
     "@types/bun": "latest",
     "@types/react": "^19.2.14",
-    "effect": "^3.19.17",
+    "effect": "^4.0.0-beta.100",
     "knip": "^5.86.0",
     "oxfmt": "^0.32.0",
     "oxlint": "^1.47.0",
@@ -60,7 +60,7 @@
     "typescript": "^5"
   },
   "peerDependencies": {
-    "effect": "^3.19.17"
+    "effect": "^4.0.0-beta.100"
   },
   "engines": {
     "node": ">=20.12.0"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "prepare": "effect-language-service patch",
     "build": "tsdown",
     "prepublishOnly": "bun run build",
+    "test": "bun test",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint .",
     "format": "oxfmt --write .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effective-progress",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Effect-first terminal progress bars with nested multibar support",
   "homepage": "https://github.com/stromseng/effective-progress#readme",
   "bugs": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -37,18 +37,16 @@ const provideProgress = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
     if (Option.isSome(existing)) {
       return yield* Effect.provideService(effect, Progress, existing.value);
     }
-    return yield* Effect.scoped(effect.pipe(Effect.provide(Progress.Default)));
+    return yield* Effect.scoped(Effect.provide(effect, Progress.layer, { local: true }));
   });
 
 export interface EffectExecutionOptions {
   readonly concurrency?: Concurrency;
-  readonly batching?: boolean | "inherit";
-  readonly concurrentFinalizers?: boolean;
 }
 
 export interface EffectAllExecutionOptions extends EffectExecutionOptions {
   readonly discard?: boolean;
-  readonly mode?: "default" | "validate" | "either";
+  readonly mode?: "default" | "result";
 }
 
 export type AllOptions = Omit<TrackOptions, "total" | "countDisplay"> & EffectAllExecutionOptions;
@@ -59,9 +57,9 @@ export type AllReturn<
   O extends EffectAllExecutionOptions,
 > = [
   [Arg] extends [ReadonlyArray<Effect.Effect<any, any, any>>]
-    ? Effect.All.ReturnTuple<Arg, Effect.All.IsDiscard<O>, Effect.All.ExtractMode<O>>
+    ? Effect.All.ReturnTuple<Arg, Effect.All.IsDiscard<O>, Effect.All.IsResult<O>>
     : [Arg] extends [Record<string, Effect.Effect<any, any, any>>]
-      ? Effect.All.ReturnObject<Arg, Effect.All.IsDiscard<O>, Effect.All.ExtractMode<O>>
+      ? Effect.All.ReturnObject<Arg, Effect.All.IsDiscard<O>, Effect.All.IsResult<O>>
       : never,
 ] extends [Effect.Effect<infer A, infer E, infer R>]
   ? Effect.Effect<A, E, Exclude<R, Progress | Task>>
@@ -115,8 +113,7 @@ const wrapEffects = (
 const countEffects = (effects: AllArg) =>
   Array.isArray(effects) ? effects.length : Object.keys(effects).length;
 
-const isCollectAllMode = (mode: EffectAllExecutionOptions["mode"]) =>
-  mode === "either" || mode === "validate";
+const isCollectAllMode = (mode: EffectAllExecutionOptions["mode"]) => mode === "result";
 
 const allCountDisplay = (mode: EffectAllExecutionOptions["mode"]): TaskCountDisplay =>
   isCollectAllMode(mode) ? "detailed" : "processedOnly";
@@ -134,7 +131,7 @@ const wrapTrackedEffect = (
       return exit.value;
     }
 
-    if (Cause.isInterruptedOnly(exit.cause)) {
+    if (Cause.hasInterruptsOnly(exit.cause)) {
       return yield* Effect.failCause(exit.cause);
     }
 
@@ -183,10 +180,8 @@ export const all: {
                   wrapEffects(effects, (effect) => wrapTrackedEffect(progress, taskId, effect)),
                   {
                     concurrency: options.concurrency,
-                    batching: options.batching,
                     discard: options.discard,
                     mode: options.mode,
-                    concurrentFinalizers: options.concurrentFinalizers,
                   },
                 ),
               );
@@ -253,9 +248,7 @@ export const forEach: {
                   (item, index) => wrapTrackedEffect(progress, taskId, f(item, index)),
                   {
                     concurrency: options.concurrency,
-                    batching: options.batching,
                     discard: options.discard,
-                    concurrentFinalizers: options.concurrentFinalizers,
                   },
                 ),
               );

--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -24,11 +24,25 @@ interface InternalTaskApi {
   ): Effect.Effect<A, E, Exclude<R, Task>>;
 }
 
+interface CurrentParentState {
+  readonly owner: symbol;
+  readonly taskId: TaskId;
+}
+
 /** Builds the scoped implementation used by `ProgressService.task(...)` without auto-providing services. */
 const makeProgressService = Effect.gen(function* () {
   const inkRenderer = yield* Renderer;
   const store = yield* ProgressStore;
   const scope = yield* Effect.scope;
+  const parentOwner = Symbol();
+
+  // Each Progress service has its own task store, but they all share CurrentParent.
+  // Ignore parent IDs created by another service so tasks never point into the wrong store.
+  const currentParentId = Effect.map(CurrentParent, (cp) =>
+    Option.isSome(cp) && cp.value.owner === parentOwner
+      ? Option.some(cp.value.taskId)
+      : Option.none<TaskId>(),
+  );
 
   const log = (...args: ReadonlyArray<unknown>) =>
     args.length === 0 ? Effect.void : Effect.log(...args);
@@ -40,7 +54,7 @@ const makeProgressService = Effect.gen(function* () {
   const addTask = (options: AddTaskOptions) =>
     Effect.gen(function* () {
       const resolvedParentId =
-        options.parentId === undefined ? yield* CurrentParent : Option.some(options.parentId);
+        options.parentId === undefined ? yield* currentParentId : Option.some(options.parentId);
       return yield* store.addTask({
         ...options,
         parentId: Option.isSome(resolvedParentId) ? resolvedParentId.value : undefined,
@@ -87,7 +101,7 @@ const makeProgressService = Effect.gen(function* () {
 
   const scopedTask = dual(2, <A, E, R>(effect: Effect.Effect<A, E, R>, options: AddTaskOptions) =>
     Effect.gen(function* () {
-      const inheritedParentId = yield* CurrentParent;
+      const inheritedParentId = yield* currentParentId;
       const resolvedParentId =
         options.parentId === undefined ? inheritedParentId : Option.some(options.parentId);
 
@@ -100,7 +114,7 @@ const makeProgressService = Effect.gen(function* () {
       return yield* Effect.provideService(
         Effect.provideService(effect, Task, taskId),
         CurrentParent,
-        Option.some(taskId),
+        Option.some({ owner: parentOwner, taskId }),
       );
     }),
   ) as InternalTaskApi;
@@ -183,7 +197,7 @@ const serviceOptionDefaultLayer = <I, S, E, R>(
     ),
   );
 
-const CurrentParent = Context.Reference<Option.Option<TaskId>>(
+const CurrentParent = Context.Reference<Option.Option<CurrentParentState>>(
   "stromseng.dev/effective-progress/CurrentParent",
   { defaultValue: Option.none },
 );

--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Exit, FiberRef, Layer, Option } from "effect";
+import { Context, Effect, Exit, Layer, Option } from "effect";
 import { dual } from "effect/Function";
 import { ProgressStore } from "./store/store";
 import type { AddTaskOptions, ProgressShape, TaskHandle, TaskId } from "../types";
@@ -27,24 +27,20 @@ interface InternalTaskApi {
 /** Builds the scoped implementation used by `ProgressService.task(...)` without auto-providing services. */
 const makeProgressService = Effect.gen(function* () {
   const inkRenderer = yield* Renderer;
-  const outerConsole = yield* Effect.console;
   const store = yield* ProgressStore;
-  const currentParentRef = yield* FiberRef.make(Option.none<TaskId>());
   const scope = yield* Effect.scope;
 
   const log = (...args: ReadonlyArray<unknown>) =>
-    args.length === 0 ? Effect.void : outerConsole.log(...args);
+    args.length === 0 ? Effect.void : Effect.log(...args);
 
-  yield* Effect.forkIn(inkRenderer.run, scope);
+  yield* Effect.forkIn(inkRenderer.run, scope, { startImmediately: true });
   // Let the renderer fiber start so queued logs are reliably flushed on scope teardown.
   yield* Effect.sleep("0 millis");
 
   const addTask = (options: AddTaskOptions) =>
     Effect.gen(function* () {
       const resolvedParentId =
-        options.parentId === undefined
-          ? yield* FiberRef.get(currentParentRef)
-          : Option.some(options.parentId);
+        options.parentId === undefined ? yield* CurrentParent : Option.some(options.parentId);
       return yield* store.addTask({
         ...options,
         parentId: Option.isSome(resolvedParentId) ? resolvedParentId.value : undefined,
@@ -91,7 +87,7 @@ const makeProgressService = Effect.gen(function* () {
 
   const scopedTask = dual(2, <A, E, R>(effect: Effect.Effect<A, E, R>, options: AddTaskOptions) =>
     Effect.gen(function* () {
-      const inheritedParentId = yield* FiberRef.get(currentParentRef);
+      const inheritedParentId = yield* CurrentParent;
       const resolvedParentId =
         options.parentId === undefined ? inheritedParentId : Option.some(options.parentId);
 
@@ -101,9 +97,9 @@ const makeProgressService = Effect.gen(function* () {
         transient: options.transient,
       });
 
-      return yield* Effect.locally(
+      return yield* Effect.provideService(
         Effect.provideService(effect, Task, taskId),
-        currentParentRef,
+        CurrentParent,
         Option.some(taskId),
       );
     }),
@@ -175,10 +171,10 @@ const makeProgressService = Effect.gen(function* () {
  * or falls back to the supplied default layer otherwise.
  */
 const serviceOptionDefaultLayer = <I, S, E, R>(
-  tag: Context.Tag<I, S>,
+  tag: Context.Key<I, S>,
   defaultLayer: Layer.Layer<I, E, R>,
 ) =>
-  Layer.unwrapEffect(
+  Layer.unwrap(
     Effect.map(Effect.serviceOption(tag), (option) =>
       Option.getOrElse(
         Option.map(option, (service) => Layer.succeed(tag, service)),
@@ -187,15 +183,19 @@ const serviceOptionDefaultLayer = <I, S, E, R>(
     ),
   );
 
-export class Progress extends Context.Tag("stromseng.dev/effective-progress/Progress")<
-  Progress,
-  ProgressShape
->() {
-  static readonly Default = Layer.scoped(Progress, makeProgressService).pipe(
+const CurrentParent = Context.Reference<Option.Option<TaskId>>(
+  "stromseng.dev/effective-progress/CurrentParent",
+  { defaultValue: Option.none },
+);
+
+export class Progress extends Context.Service<Progress, ProgressShape>()(
+  "stromseng.dev/effective-progress/Progress",
+) {
+  static readonly layer = Layer.effect(Progress, makeProgressService).pipe(
     Layer.provide(
-      serviceOptionDefaultLayer(Renderer, Renderer.Default).pipe(
-        Layer.provideMerge(serviceOptionDefaultLayer(ProgressStdio, ProgressStdio.Default)),
-        Layer.provideMerge(ProgressStore.Default),
+      serviceOptionDefaultLayer(Renderer, Renderer.layer).pipe(
+        Layer.provideMerge(serviceOptionDefaultLayer(ProgressStdio, ProgressStdio.layer)),
+        Layer.provideMerge(ProgressStore.layer),
       ),
     ),
   );

--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -44,8 +44,7 @@ const makeProgressService = Effect.gen(function* () {
       : Option.none<TaskId>(),
   );
 
-  const log = (...args: ReadonlyArray<unknown>) =>
-    args.length === 0 ? Effect.void : Effect.log(...args);
+  const log = (...args: ReadonlyArray<unknown>) => Effect.log(...args);
 
   yield* Effect.forkIn(inkRenderer.run, scope, { startImmediately: true });
   // Let the renderer fiber start so queued logs are reliably flushed on scope teardown.

--- a/src/services/renderer/public-api.tsx
+++ b/src/services/renderer/public-api.tsx
@@ -51,7 +51,7 @@ const ColumnPosition = ({ position }: { readonly position: ResolvedColumnPositio
         const cell = row;
         const output =
           column?.render(cell, {
-            width: hasMeasured ? width : undefined,
+            width: hasMeasured ? width : position.flexBasis,
             now,
             spinnerTick,
             prepared: entry?.prepared as never,

--- a/src/services/renderer/renderer.tsx
+++ b/src/services/renderer/renderer.tsx
@@ -58,9 +58,8 @@ const makeRendererv2InkRendererService = Effect.gen(function* () {
   } satisfies RendererShape;
 });
 
-export class Renderer extends Context.Tag("stromseng.dev/effective-progress/Renderer")<
-  Renderer,
-  RendererShape
->() {
-  static readonly Default = Layer.effect(Renderer, makeRendererv2InkRendererService);
+export class Renderer extends Context.Service<Renderer, RendererShape>()(
+  "stromseng.dev/effective-progress/Renderer",
+) {
+  static readonly layer = Layer.effect(Renderer, makeRendererv2InkRendererService);
 }

--- a/src/services/stdio.ts
+++ b/src/services/stdio.ts
@@ -10,9 +10,8 @@ const defaultStdioService: ProgressStdioShape = {
   stderr: process.stderr,
 };
 
-export class ProgressStdio extends Context.Tag("stromseng.dev/effective-progress/ProgressStdio")<
-  ProgressStdio,
-  ProgressStdioShape
->() {
-  static readonly Default = Layer.succeed(ProgressStdio, defaultStdioService);
+export class ProgressStdio extends Context.Service<ProgressStdio, ProgressStdioShape>()(
+  "stromseng.dev/effective-progress/ProgressStdio",
+) {
+  static readonly layer = Layer.succeed(ProgressStdio, defaultStdioService);
 }

--- a/src/services/store/store.ts
+++ b/src/services/store/store.ts
@@ -271,7 +271,7 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
       const now = yield* Clock.currentTimeMillis;
       const waitMillis = Math.max(0, SNAPSHOT_PUBLISH_INTERVAL_MILLIS - (now - lastPublishAt));
       if (waitMillis > 0) {
-        yield* Clock.sleep(waitMillis);
+        yield* Effect.sleep(waitMillis);
       }
       if (!hasPendingPublish) {
         return;
@@ -629,7 +629,7 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
           };
         }, now);
       }),
-    getTask: (taskId) => Effect.sync(() => Option.fromNullable(state.tasks.get(taskId))),
+    getTask: (taskId) => Effect.sync(() => Option.fromNullishOr(state.tasks.get(taskId))),
     listTasks: Effect.sync(() => Array.from(state.tasks.values())),
     setMetadata: (taskId, metadata) =>
       Effect.gen(function* () {
@@ -663,13 +663,12 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
 export const makeProgressStore: Effect.Effect<ProgressStoreShape> = Effect.gen(function* () {
   const publishQueue = yield* Queue.sliding<void>(1);
   const runtime = makeProgressStoreRuntime(publishQueue);
-  yield* Effect.forkDaemon(runtime.publisherLoop);
+  yield* Effect.forkDetach(runtime.publisherLoop);
   return runtime.store;
 });
 
-export class ProgressStore extends Context.Tag("stromseng.dev/effective-progress/ProgressStore")<
-  ProgressStore,
-  ProgressStoreShape
->() {
-  static readonly Default = Layer.effect(ProgressStore, makeProgressStore);
+export class ProgressStore extends Context.Service<ProgressStore, ProgressStoreShape>()(
+  "stromseng.dev/effective-progress/ProgressStore",
+) {
+  static readonly layer = Layer.effect(ProgressStore, makeProgressStore);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,10 +6,10 @@ const TaskIdSchema = Schema.Number.pipe(Schema.brand("TaskId"));
 export type TaskId = typeof TaskIdSchema.Type;
 export const TaskId = Brand.nominal<TaskId>();
 
-export const TaskStatusSchema = Schema.Literal("running", "done", "failed");
+export const TaskStatusSchema = Schema.Literals(["running", "done", "failed"]);
 
 export type TaskStatus = typeof TaskStatusSchema.Type;
-export const TaskCountDisplaySchema = Schema.Literal("processedOnly", "detailed");
+export const TaskCountDisplaySchema = Schema.Literals(["processedOnly", "detailed"]);
 export type TaskCountDisplay = typeof TaskCountDisplaySchema.Type;
 export type ColumnAlign = "left" | "center" | "right";
 
@@ -195,7 +195,9 @@ export interface ProgressShape {
   };
 }
 
-export class Task extends Context.Tag("stromseng.dev/effective-progress/Task")<Task, TaskId>() {}
+export class Task extends Context.Service<Task, TaskId>()(
+  "stromseng.dev/effective-progress/Task",
+) {}
 
 export class TaskAddedEvent extends Schema.TaggedClass<TaskAddedEvent>()("TaskAdded", {
   taskId: TaskIdSchema,
@@ -220,7 +222,7 @@ export class TaskUpdatedEvent extends Schema.TaggedClass<TaskUpdatedEvent>()("Ta
 export class TaskAdvancedEvent extends Schema.TaggedClass<TaskAdvancedEvent>()("TaskAdvanced", {
   taskId: TaskIdSchema,
   amount: Schema.Number,
-  kind: Schema.Literal("succeeded", "failed"),
+  kind: Schema.Literals(["succeeded", "failed"]),
 }) {}
 
 export class TaskCompletedEvent extends Schema.TaggedClass<TaskCompletedEvent>()("TaskCompleted", {
@@ -235,14 +237,14 @@ export class TaskRemovedEvent extends Schema.TaggedClass<TaskRemovedEvent>()("Ta
   taskId: TaskIdSchema,
 }) {}
 
-export const ProgressTaskEventSchema = Schema.Union(
+export const ProgressTaskEventSchema = Schema.Union([
   TaskAddedEvent,
   TaskUpdatedEvent,
   TaskAdvancedEvent,
   TaskCompletedEvent,
   TaskFailedEvent,
   TaskRemovedEvent,
-);
+]);
 
 export type ProgressTaskEvent = typeof ProgressTaskEventSchema.Type;
 

--- a/tests/ink-format.test.ts
+++ b/tests/ink-format.test.ts
@@ -67,7 +67,7 @@ describe("determinate processed amount color", () => {
     expect(getDeterminateProcessedColor(task)).toBe("red");
   });
 
-  test("red for all failed after full validation", () => {
+  test("red when all result-mode effects failed", () => {
     const task = makeTask(
       {
         succeeded: 0,

--- a/tests/ink-renderer-store.test.ts
+++ b/tests/ink-renderer-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { Effect, Option, TestClock, TestContext } from "effect";
+import { Effect, Option } from "effect";
+import { TestClock } from "effect/testing";
 import type { ColumnDef } from "../src";
 import { makeProgressStore } from "../src/services/store/store";
 
@@ -42,7 +43,7 @@ describe("progress render store", () => {
         expect(task?.units.failed).toBe(1);
         expect(task?.units.processed).toBe(3);
         expect(publication.events).toHaveLength(3);
-      }).pipe(Effect.provide(TestContext.TestContext)),
+      }).pipe(Effect.provide(TestClock.layer())),
     );
   });
 
@@ -77,7 +78,7 @@ describe("progress render store", () => {
 
         yield* TestClock.adjust(100);
         expect(notifications).toBe(2);
-      }).pipe(Effect.provide(TestContext.TestContext)),
+      }).pipe(Effect.provide(TestClock.layer())),
     );
   });
 
@@ -306,7 +307,7 @@ describe("progress render store", () => {
         expect(Option.isSome(task) ? task.value.progressSamples : []).toEqual([
           { timestamp: 0, processed: 0 },
         ]);
-      }).pipe(Effect.provide(TestContext.TestContext)),
+      }).pipe(Effect.provide(TestClock.layer())),
     );
   });
 
@@ -330,7 +331,7 @@ describe("progress render store", () => {
         expect(samples).toHaveLength(1_000);
         expect(samples[0]).toEqual({ timestamp: 0, processed: 6 });
         expect(samples.at(-1)).toEqual({ timestamp: 0, processed: 1_005 });
-      }).pipe(Effect.provide(TestContext.TestContext)),
+      }).pipe(Effect.provide(TestClock.layer())),
     );
   });
 
@@ -357,7 +358,7 @@ describe("progress render store", () => {
           { timestamp: 2_000, processed: 2 },
           { timestamp: 33_000, processed: 3 },
         ]);
-      }).pipe(Effect.provide(TestContext.TestContext)),
+      }).pipe(Effect.provide(TestClock.layer())),
     );
   });
 });

--- a/tests/ink-renderer.test.ts
+++ b/tests/ink-renderer.test.ts
@@ -71,22 +71,15 @@ describe("Ink renderer integration", () => {
 
     const result = await captureStdioOutput(
       Effect.gen(function* () {
-        const outer = yield* Console.consoleWith((console) => Effect.succeed(console));
+        const outer = yield* Console.Console;
         const consoleSpy: Console.Console = {
           ...outer,
           log: (...args) => {
             logs.push(args);
-            return Effect.void;
-          },
-          unsafe: {
-            ...outer.unsafe,
-            log: (...args) => {
-              logs.push(args);
-            },
           },
         };
 
-        return yield* Effect.withConsole(
+        return yield* Effect.provideService(
           Progress.task(
             Effect.gen(function* () {
               yield* Console.log("custom-log-line");
@@ -94,6 +87,7 @@ describe("Ink renderer integration", () => {
             }),
             { description: "log-task", transient: false },
           ),
+          Console.Console,
           consoleSpy,
         );
       }),
@@ -344,7 +338,7 @@ describe("Ink renderer integration", () => {
           yield* progress.failTask(failFastId);
 
           const detailedId = yield* progress.addTask({
-            description: "either mode (collect all outcomes)",
+            description: "result mode (collect all outcomes)",
             total: 4,
             transient: false,
             countDisplay: "detailed",

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { Console, Effect, Exit, Logger, Option, Result } from "effect";
 import { pipe } from "effect/Function";
 import * as Progress from "../src";
+import { Renderer } from "../src/services/renderer/renderer";
 import { createMockStdio } from "./helpers/mock-stdio";
 
 const withLogSpy = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
@@ -71,6 +72,30 @@ describe("Progress.run", () => {
     );
 
     expect(reused).toBeTrue();
+  });
+
+  test("isolated nested Progress layer does not inherit the outer parent", async () => {
+    const inner = Effect.gen(function* () {
+      const progress = yield* Progress.Progress;
+      yield* progress.task(Effect.void, {
+        description: "isolated-inner",
+        transient: false,
+      });
+      return getTaskByDescription(yield* progress.listTasks, "isolated-inner");
+    });
+
+    const outer = Effect.gen(function* () {
+      const isolatedInner = Effect.scoped(
+        Effect.provide(inner, Progress.Progress.layer, { local: true }),
+      );
+      return yield* Progress.task(isolatedInner, { description: "outer", transient: false });
+    });
+
+    const innerTask = await Effect.runPromise(
+      withStdio(Effect.provideService(outer, Renderer, { run: Effect.never })),
+    );
+
+    expect(innerTask.parentId).toBeNull();
   });
 
   test("manual task delegates Console.log to the outer console and provides Task context", async () => {

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -157,6 +157,28 @@ describe("Progress.run", () => {
     ).toBe("Info");
   });
 
+  test("Progress.log forwards zero-argument calls to Effect loggers", async () => {
+    const { logs } = await Effect.runPromise(
+      withLoggerSpy(
+        withStdio(
+          Progress.task(
+            Effect.gen(function* () {
+              const progress = yield* Progress.Progress;
+              yield* progress.log();
+            }),
+            { description: "empty-log-message", transient: true },
+          ),
+        ),
+      ),
+    );
+
+    const emptyMessageLog = logs.find(
+      (entry) => Array.isArray(entry.message) && entry.message.length === 0,
+    );
+    expect(emptyMessageLog).toBeDefined();
+    expect(emptyMessageLog?.logLevel).toBe("Info");
+  });
+
   test("all returns the values from each effect", async () => {
     const result = await Effect.runPromise(
       withStdio(

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -1,35 +1,37 @@
 import { describe, expect, test } from "bun:test";
-import { Console, Effect, Exit, Option } from "effect";
+import { Console, Effect, Exit, Logger, Option, Result } from "effect";
 import { pipe } from "effect/Function";
 import * as Progress from "../src";
 import { createMockStdio } from "./helpers/mock-stdio";
 
 const withLogSpy = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   Effect.gen(function* () {
-    const outer = yield* Console.consoleWith((console) => Effect.succeed(console));
+    const outer = yield* Console.Console;
     const logs: Array<ReadonlyArray<unknown>> = [];
 
     const consoleSpy: Console.Console = {
       ...outer,
       log: (...args) => {
         logs.push(args);
-        return Effect.void;
-      },
-      unsafe: {
-        ...outer.unsafe,
-        log: (...args) => {
-          logs.push(args);
-        },
       },
     };
 
-    const result = yield* Effect.withConsole(effect, consoleSpy);
+    const result = yield* Effect.provideService(effect, Console.Console, consoleSpy);
     return { result, logs };
   });
 
 const withStdio = <A, E, R>(effect: Effect.Effect<A, E, R>) => {
   const stdio = createMockStdio();
   return effect.pipe(Effect.provideService(Progress.ProgressStdio, stdio.service));
+};
+
+const withLoggerSpy = <A, E, R>(effect: Effect.Effect<A, E, R>) => {
+  const logs: Array<Logger.Options<unknown>> = [];
+  const logger = Logger.make<unknown, void>((options) => {
+    logs.push(options);
+  });
+
+  return Effect.map(Effect.provide(effect, Logger.layer([logger])), (result) => ({ result, logs }));
 };
 
 const getTaskByDescription = (
@@ -102,6 +104,34 @@ describe("Progress.run", () => {
     expect(result).toBeTrue();
   });
 
+  test("task preserves Effect v4 loggers and routes Progress.log through them", async () => {
+    const { logs } = await Effect.runPromise(
+      withLoggerSpy(
+        withStdio(
+          Progress.task(
+            Effect.gen(function* () {
+              yield* Effect.logInfo("effect-log");
+              const progress = yield* Progress.Progress;
+              yield* progress.log("progress-log");
+            }),
+            { description: "logger-task", transient: true },
+          ),
+        ),
+      ),
+    );
+
+    const messages = logs.flatMap((entry) =>
+      Array.isArray(entry.message) ? entry.message : [entry.message],
+    );
+    expect(messages).toContain("effect-log");
+    expect(messages).toContain("progress-log");
+    expect(
+      logs.find((entry) =>
+        (Array.isArray(entry.message) ? entry.message : [entry.message]).includes("effect-log"),
+      )?.logLevel,
+    ).toBe("Info");
+  });
+
   test("all returns the values from each effect", async () => {
     const result = await Effect.runPromise(
       withStdio(
@@ -137,22 +167,15 @@ describe("Progress.run", () => {
 
     const result = await Effect.runPromise(
       Effect.gen(function* () {
-        const outer = yield* Console.consoleWith((console) => Effect.succeed(console));
+        const outer = yield* Console.Console;
         const consoleSpy: Console.Console = {
           ...outer,
           dir: (item, nextOptions) => {
             captured = { item, options: nextOptions };
-            return Effect.void;
-          },
-          unsafe: {
-            ...outer.unsafe,
-            dir: (item, nextOptions) => {
-              captured = { item, options: nextOptions };
-            },
           },
         };
 
-        return yield* Effect.withConsole(
+        return yield* Effect.provideService(
           withStdio(
             Progress.task(
               Effect.gen(function* () {
@@ -162,6 +185,7 @@ describe("Progress.run", () => {
               { description: "dir-replay" },
             ),
           ),
+          Console.Console,
           consoleSpy,
         );
       }),
@@ -226,7 +250,7 @@ describe("Progress.run", () => {
             });
             const task = getTaskByDescription(yield* progress.listTasks, description);
             return { value, task };
-          }).pipe(Effect.provide(Progress.Progress.Default)),
+          }).pipe(Effect.provide(Progress.Progress.layer)),
         ),
       ),
     );
@@ -248,7 +272,7 @@ describe("Progress.run", () => {
             });
             const task = getTaskByDescription(yield* progress.listTasks, description);
             return { value, task };
-          }).pipe(Effect.provide(Progress.Progress.Default)),
+          }).pipe(Effect.provide(Progress.Progress.layer)),
         ),
       ),
     );
@@ -274,7 +298,7 @@ describe("Progress.run", () => {
             );
             const task = getTaskByDescription(yield* progress.listTasks, description);
             return { value, task };
-          }).pipe(Effect.provide(Progress.Progress.Default)),
+          }).pipe(Effect.provide(Progress.Progress.layer)),
         ),
       ),
     );
@@ -297,7 +321,7 @@ describe("Progress.run", () => {
             });
             const task = getTaskByDescription(yield* progress.listTasks, description);
             return { value, task };
-          }).pipe(Effect.provide(Progress.Progress.Default)),
+          }).pipe(Effect.provide(Progress.Progress.layer)),
         ),
       ),
     );
@@ -326,7 +350,7 @@ describe("Progress.run", () => {
             );
             const task = getTaskByDescription(yield* progress.listTasks, description);
             return { exit, task };
-          }).pipe(Effect.provide(Progress.Progress.Default)),
+          }).pipe(Effect.provide(Progress.Progress.layer)),
         ),
       ),
     );
@@ -341,27 +365,32 @@ describe("Progress.run", () => {
     expect(result.task.units.total).toBe(3);
   });
 
-  test("all either mode completes with mixed succeeded/failed counters", async () => {
+  test("all result mode completes with mixed succeeded/failed counters", async () => {
     const result = await Effect.runPromise(
       withStdio(
         Effect.scoped(
           Effect.gen(function* () {
             const progress = yield* Progress.Progress;
-            const description = "all-either-counters";
+            const description = "all-result-counters";
             const exit = yield* Effect.exit(
               Progress.all([Effect.succeed("ok-1"), Effect.fail("bad"), Effect.succeed("ok-2")], {
                 description,
-                mode: "either",
+                mode: "result",
               }),
             );
             const task = getTaskByDescription(yield* progress.listTasks, description);
             return { exit, task };
-          }).pipe(Effect.provide(Progress.Progress.Default)),
+          }).pipe(Effect.provide(Progress.Progress.layer)),
         ),
       ),
     );
 
     expect(Exit.isSuccess(result.exit)).toBeTrue();
+    if (Exit.isSuccess(result.exit)) {
+      expect(Result.isSuccess(result.exit.value[0])).toBeTrue();
+      expect(Result.isFailure(result.exit.value[1])).toBeTrue();
+      expect(Result.isSuccess(result.exit.value[2])).toBeTrue();
+    }
     expect(result.task.status).toBe("done");
     expect(result.task.countDisplay).toBe("detailed");
     expect(result.task.units.total).toBe(3);
@@ -371,34 +400,33 @@ describe("Progress.run", () => {
     expect(result.task.units.total).toBe(3);
   });
 
-  test("all validate mode completes task after full accounting even when effect fails", async () => {
+  test("all result mode completes after accounting for all failures", async () => {
     const result = await Effect.runPromise(
       withStdio(
         Effect.scoped(
           Effect.gen(function* () {
             const progress = yield* Progress.Progress;
-            const description = "all-validate-counters";
+            const description = "all-result-failure-counters";
             const exit = yield* Effect.exit(
-              Progress.all([Effect.succeed("ok-1"), Effect.fail("bad"), Effect.succeed("ok-2")], {
+              Progress.all([Effect.fail("bad-1"), Effect.fail("bad-2")], {
                 description,
-                mode: "validate",
+                mode: "result",
               }),
             );
             const task = getTaskByDescription(yield* progress.listTasks, description);
             return { exit, task };
-          }).pipe(Effect.provide(Progress.Progress.Default)),
+          }).pipe(Effect.provide(Progress.Progress.layer)),
         ),
       ),
     );
 
-    expect(Exit.isFailure(result.exit)).toBeTrue();
+    expect(Exit.isSuccess(result.exit)).toBeTrue();
     expect(result.task.status).toBe("done");
     expect(result.task.countDisplay).toBe("detailed");
-    expect(result.task.units.total).toBe(3);
-    expect(result.task.units.succeeded).toBe(2);
-    expect(result.task.units.failed).toBe(1);
-    expect(result.task.units.processed).toBe(3);
-    expect(result.task.units.total).toBe(3);
+    expect(result.task.units.total).toBe(2);
+    expect(result.task.units.succeeded).toBe(0);
+    expect(result.task.units.failed).toBe(2);
+    expect(result.task.units.processed).toBe(2);
   });
 
   test("forEach fail-fast does not account unresolved items", async () => {
@@ -417,7 +445,7 @@ describe("Progress.run", () => {
             );
             const task = getTaskByDescription(yield* progress.listTasks, description);
             return { exit, task };
-          }).pipe(Effect.provide(Progress.Progress.Default)),
+          }).pipe(Effect.provide(Progress.Progress.layer)),
         ),
       ),
     );
@@ -453,7 +481,7 @@ describe("Progress.run", () => {
             );
             const task = getTaskByDescription(yield* progress.listTasks, description);
             return { value, task };
-          }).pipe(Effect.provide(Progress.Progress.Default)),
+          }).pipe(Effect.provide(Progress.Progress.layer)),
         ),
       ),
     );
@@ -485,7 +513,7 @@ describe("Progress.run", () => {
             );
             const task = getTaskByDescription(yield* progress.listTasks, description);
             return { exit, task };
-          }).pipe(Effect.provide(Progress.Progress.Default)),
+          }).pipe(Effect.provide(Progress.Progress.layer)),
         ),
       ),
     );
@@ -519,7 +547,7 @@ describe("Progress.run", () => {
               completed: getTaskByDescription(yield* progress.listTasks, "terminal-complete"),
               failed: getTaskByDescription(yield* progress.listTasks, "terminal-fail"),
             };
-          }).pipe(Effect.provide(Progress.Progress.Default)),
+          }).pipe(Effect.provide(Progress.Progress.layer)),
         ),
       ),
     );

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -9,7 +9,7 @@ const withStdio = <A, E, R>(effect: Effect.Effect<A, E, R>) => {
 };
 
 const withProgress = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-  Effect.scoped(effect.pipe(Effect.provide(Progress.Progress.Default)));
+  Effect.scoped(effect.pipe(Effect.provide(Progress.Progress.layer)));
 
 const getTaskOrFail = (
   task: Option.Option<Progress.TaskSnapshot>,

--- a/tests/stdio.test.ts
+++ b/tests/stdio.test.ts
@@ -46,7 +46,7 @@ describe("ProgressStdio", () => {
           stdout: stdio.stdout,
           stderr: stdio.stderr,
         };
-      }).pipe(Effect.provide(Progress.ProgressStdio.Default)),
+      }).pipe(Effect.provide(Progress.ProgressStdio.layer)),
     );
 
     expect(result.stdout).toBe(process.stdout);


### PR DESCRIPTION
## Summary

- upgrade the development and peer dependency to Effect 4.0.0-beta.100
- migrate services, layers, schemas, causes, forks, test clock imports, and collection options to v4 APIs
- replace FiberRef parent tracking with Context.Reference and route Progress.log through the v4 logger system
- update examples and README for Logger.layer, consolePretty, and Effect.all result mode
- keep automatic progress layers isolated from v4 shared layer memoization while preserving nested service reuse

## Verification

- bun run check
- bun test (105 passing)