### PR TITLE
Run tests and static checks on pull requests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,32 @@
+name: Check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Tests and static checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck, lint, formatting, and unused code
+        run: bun run check
+
+      - name: Test
+        run: bun test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,9 @@ permissions:
 jobs:
   verify:
     name: Verify
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Typecheck
-        run: bunx tsc --noEmit
+    uses: ./.github/workflows/check.yml
+    permissions:
+      contents: read
 
   publish:
     name: Publish to npm


### PR DESCRIPTION
Add a reusable Check workflow for pull requests and pushes to main, running full static checks and tests with Bun 1.3.13 and a frozen lockfile. Reuse it as the release verification job so publishing is gated on the same checks instead of typechecking alone.

Validation: `bun run format`, `bun run check`, and `bun test` (107 passing). Also validated both workflows with actionlint 1.7.12 and ran all tests with CI=true.
