### PR TITLE
Reuse internal default column definitions

### DIFF
--- a/src/services/renderer/column-resolver.ts
+++ b/src/services/renderer/column-resolver.ts
@@ -26,10 +26,12 @@ export interface ResolvedColumnPosition {
   readonly minWidth?: number;
 }
 
+const DEFAULT_COLUMNS = defaults();
+
 const getColumnsForRow = (
   row: TaskRowModel,
   columns: Map<TaskId, ReadonlyArray<ColumnDef<any, any>>>,
-): ReadonlyArray<ColumnDef<any, any>> => columns.get(row.task.id) ?? defaults();
+): ReadonlyArray<ColumnDef<any, any>> => columns.get(row.task.id) ?? DEFAULT_COLUMNS;
 
 const toCellInfo = (row: TaskRowModel): CellInfo<unknown> => row;
 


### PR DESCRIPTION
Each defaulted row currently allocates a new default column array and render/sizing closures on every resolution. Reuse a module-local default set in the resolver; the public Columns.defaults() factory retains its existing behavior.

Validation: `bun run format`, `bun run check`, and `bun test` (107 passing). Includes custom-column and sizing coverage.

Two runs of the same benchmark harness (3 warmups, 9 measured rounds, 20 resolutions per sample) reduced the 1,000-row default case from 5.03–5.28 ms to 4.37–4.48 ms per sample. These are local resolver measurements on Bun 1.3.13/macOS arm64, not end-to-end rendering results.

Benchmark harness: https://github.com/stromseng/effective-progress/pull/14.
