### PR TITLE
Reuse the render snapshot running-task flag

### DIFF
--- a/src/services/renderer/hooks/use-progress-render-view.ts
+++ b/src/services/renderer/hooks/use-progress-render-view.ts
@@ -26,11 +26,10 @@ const useRenderSnapshot = (storeSnapshot: RenderPublication["snapshot"]): Render
 export const useProgressRenderView = (store: ProgressStoreShape): ProgressRenderView => {
   const publication = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
   const renderSnapshot = useRenderSnapshot(publication.snapshot);
-  const hasRunningTasks = renderSnapshot.rows.some((row) => row.task.status === "running");
 
   return {
     publication,
     renderSnapshot,
-    hasRunningTasks,
+    hasRunningTasks: renderSnapshot.hasRunningTasks,
   };
 };


### PR DESCRIPTION
Use the running-task flag already calculated by toRenderSnapshot instead of scanning every rendered row again in useProgressRenderView.

Validation: `bun run format`, `bun run check`, and `bun test` (107 passing).
