### PR TITLE
Add repeatable store and column microbenchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,24 @@ const program = Progress.task(
 
 If a task does not provide `columns`, the renderer falls back to `Progress.Columns.defaults()`.
 
+## Performance benchmarks
+
+Run `bun run bench` for isolated store-update and column-resolution measurements.
+Each fixture uses three warmup rounds and nine measured rounds, reporting JSON with
+raw samples, median/min/max time, throughput, and runtime information. Task setup,
+correctness assertions, explicit flushes, and console output are outside the timed sections;
+the benchmark does not render a terminal UI or add sleeps.
+
+The store cases update one hot task in stores of 1, 100, and 1,000 tasks. Column cases
+resolve 100 and 1,000 rows using defaults or distinct custom prepare functions. Every
+round checks final counters or prepared/layout output and exits with an error on a mismatch.
+
+To compare a change, run the same benchmark on both revisions with the same Bun
+version and machine, without other CPU-heavy work. Alternate revision order across
+multiple runs and compare medians and sample spread. These microbenchmarks measure
+store/resolver work; use the existing `perf` script and performance examples separately
+to investigate Ink rendering, logging, and end-to-end overhead.
+
 ## Effect compatibility
 
 This release targets Effect `4.0.0-beta.100` or newer compatible v4 prereleases. Effect v4 is still in beta, so its APIs may change between beta releases.

--- a/examples/benchmarks.ts
+++ b/examples/benchmarks.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { Effect } from "effect";
+import { resolveColumns } from "../src/services/renderer/column-resolver";
+import { toRenderSnapshot } from "../src/services/store/render-snapshot";
+import { makeProgressStore } from "../src/services/store/store";
+import { TaskId, TaskSnapshot, type ColumnDef, type TaskStore } from "../src/types";
+
+const WARMUP_ROUNDS = 3;
+const MEASURED_ROUNDS = 9;
+const STORE_UPDATES = 2_000;
+const COLUMN_RESOLUTIONS = 20;
+
+interface Measurement {
+  readonly name: string;
+  readonly operations: number;
+  readonly samplesMillis: ReadonlyArray<number>;
+}
+
+const summarize = ({ name, operations, samplesMillis }: Measurement) => {
+  const sorted = samplesMillis.toSorted((a, b) => a - b);
+  const medianMillis = sorted[Math.floor(sorted.length / 2)]!;
+  return {
+    name,
+    operationsPerSample: operations,
+    medianMillis,
+    minMillis: sorted[0]!,
+    maxMillis: sorted.at(-1)!,
+    operationsPerSecond: (operations * 1_000) / medianMillis,
+    samplesMillis,
+  };
+};
+
+// Measure updates to one hot task while varying the size of the task Map copied by the store.
+const benchmarkStore = (taskCount: number) =>
+  Effect.gen(function* () {
+    const store = yield* makeProgressStore;
+    const taskIds: TaskId[] = [];
+    for (let index = 0; index < taskCount; index++) {
+      taskIds.push(yield* store.addTask({ description: `task-${index}` }));
+    }
+    const hotTaskId = taskIds[0]!;
+    const samplesMillis: number[] = [];
+
+    for (let round = 0; round < WARMUP_ROUNDS + MEASURED_ROUNDS; round++) {
+      store.flush();
+      const started = performance.now();
+      for (let update = 0; update < STORE_UPDATES; update++) {
+        yield* store.incrementSucceeded(hotTaskId);
+      }
+      const elapsed = performance.now() - started;
+      if (round >= WARMUP_ROUNDS) {
+        samplesMillis.push(elapsed);
+      }
+
+      // Publication and correctness checks are outside the timed section.
+      store.flush();
+      const tasks = store.getSnapshot().snapshot.tasks;
+      assert.equal(tasks.size, taskCount);
+      for (const [id, task] of tasks) {
+        assert.equal(task.units.succeeded, id === hotTaskId ? (round + 1) * STORE_UPDATES : 0);
+        assert.equal(task.units.processed, task.units.succeeded);
+        assert.equal(task.units.failed, 0);
+      }
+    }
+
+    return { name: `store: ${taskCount} tasks`, operations: STORE_UPDATES, samplesMillis };
+  }).pipe(Effect.scoped);
+
+const makeColumnFixture = (rowCount: number, distinctPrepare: boolean) => {
+  const store: TaskStore = { tasks: new Map(), renderOrder: [], columns: new Map() };
+  const renderOrder: Array<TaskStore["renderOrder"][number]> = [];
+
+  for (let index = 0; index < rowCount; index++) {
+    const id = TaskId(index + 1);
+    store.tasks.set(
+      id,
+      TaskSnapshot({
+        id,
+        parentId: null,
+        description: `task-${index}`,
+        status: "running",
+        countDisplay: "detailed",
+        transient: false,
+        units: { succeeded: 25, failed: 0, processed: 25, total: 100 },
+        startedAt: 0,
+        completedAt: null,
+        progressSamples: [
+          { timestamp: 0, processed: 0 },
+          { timestamp: 1_000, processed: 25 },
+        ],
+        metadata: undefined,
+      }),
+    );
+    renderOrder.push({ id, depth: 0 });
+    if (distinctPrepare) {
+      const column: ColumnDef<unknown, number> = {
+        prepare: (cells) => index + cells.reduce((sum, cell) => sum + cell.task.units.processed, 0),
+        render: () => null,
+      };
+      store.columns.set(id, [column]);
+    }
+  }
+
+  return {
+    rows: toRenderSnapshot({ ...store, renderOrder }).rows,
+    columns: store.columns,
+  };
+};
+
+// Compare layout/prepared output without comparing newly allocated render function identities.
+const columnOutput = (positions: ReturnType<typeof resolveColumns>) =>
+  positions.map(({ index, flexGrow, flexShrink, flexBasis, minWidth, entries }) => ({
+    index,
+    flexGrow,
+    flexShrink,
+    flexBasis,
+    minWidth,
+    prepared: entries.map((entry) => entry?.prepared),
+  }));
+
+const benchmarkColumns = (rowCount: number, distinctPrepare: boolean): Measurement => {
+  const { rows, columns } = makeColumnFixture(rowCount, distinctPrepare);
+  let result = resolveColumns(rows, columns);
+  assert.equal(result.length, distinctPrepare ? 1 : 4);
+  for (const position of result) {
+    assert.equal(position.entries.length, rowCount);
+    if (distinctPrepare) {
+      position.entries.forEach((entry, index) => assert.equal(entry?.prepared, index + 25));
+    }
+  }
+  const expected = columnOutput(result);
+  const samplesMillis: number[] = [];
+
+  for (let round = 0; round < WARMUP_ROUNDS + MEASURED_ROUNDS; round++) {
+    const started = performance.now();
+    for (let iteration = 0; iteration < COLUMN_RESOLUTIONS; iteration++) {
+      result = resolveColumns(rows, columns);
+    }
+    const elapsed = performance.now() - started;
+    if (round >= WARMUP_ROUNDS) {
+      samplesMillis.push(elapsed);
+    }
+    assert.deepEqual(columnOutput(result), expected);
+  }
+
+  return {
+    name: `columns: ${rowCount} rows, ${distinctPrepare ? "distinct prepare functions" : "defaults"}`,
+    operations: COLUMN_RESOLUTIONS,
+    samplesMillis,
+  };
+};
+
+const measurements: Measurement[] = [];
+for (const taskCount of [1, 100, 1_000]) {
+  measurements.push(await Effect.runPromise(benchmarkStore(taskCount)));
+}
+for (const rowCount of [100, 1_000]) {
+  measurements.push(benchmarkColumns(rowCount, false));
+  measurements.push(benchmarkColumns(rowCount, true));
+}
+
+// Print once, after all measurements, so console/terminal work cannot distort the timings.
+console.log(
+  JSON.stringify(
+    {
+      runtime: { bun: Bun.version, platform: process.platform, arch: process.arch },
+      warmupRounds: WARMUP_ROUNDS,
+      measuredRounds: MEASURED_ROUNDS,
+      results: measurements.map(summarize),
+    },
+    null,
+    2,
+  ),
+);

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
     "check": "bun run typecheck && bun run lint && bun run format:check && knip",
+    "bench": "bun examples/benchmarks.ts",
     "perf": "bun --cpu-prof --cpu-prof-md examples/performance.ts"
   },
   "dependencies": {


### PR DESCRIPTION
Add `bun run bench` with fixed store-update and column-resolution fixtures, three warmup rounds, nine measured rounds, and JSON output containing raw samples, medians, ranges, throughput, and runtime information. Keep setup, assertions, explicit flushes, and console output outside timed sections, and verify final counters/prepared layout after every round. Document how to compare revisions and the distinction from end-to-end rendering profiles.

Validation: `bun run format`, `bun run check`, and `bun test` (107 passing). Repeated `bun run bench` runs passed all correctness assertions. The same harness was exercised against both resolver optimization branches. All nine maintenance changes were also checked together: 108 tests, static checks, and benchmarks passed.
