### PR TITLE
fix: forward custom columns through all and forEach

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -207,6 +207,7 @@ export const all: {
             description: options.description,
             total: countEffects(effects),
             transient: options.transient,
+            columns: options.columns,
             countDisplay: allCountDisplay(options.mode),
           },
         );
@@ -268,6 +269,7 @@ export const forEach: {
             description: options.description,
             total: options.total ?? inferTotal(iterable),
             transient: options.transient,
+            columns: options.columns,
             countDisplay: "processedOnly",
           },
         );

--- a/tests/ink-renderer.test.ts
+++ b/tests/ink-renderer.test.ts
@@ -36,6 +36,21 @@ const captureStdioOutput = async <A, E, R>(
 };
 
 describe("Ink renderer integration", () => {
+  test.each(["all", "forEach"] as const)("%s renders custom columns", async (method) => {
+    const options = {
+      description: "custom collection",
+      columns: [{ render: () => "CUSTOM_COLLECTION_COLUMN" }],
+    };
+    const program =
+      method === "all"
+        ? Progress.all([Effect.void], options)
+        : Progress.forEach([1], () => Effect.void, options);
+
+    const { output } = await captureStdioOutput(program, { isTTY: false });
+
+    expect(output).toContain("CUSTOM_COLLECTION_COLUMN");
+  });
+
   test("renders nested task rows", async () => {
     const program = Progress.task(
       Effect.gen(function* () {


### PR DESCRIPTION
`Progress.all` and `Progress.forEach` accept a `columns` option through their public option types, but silently discard it when constructing the parent task. A caller can supply a valid custom layout and still get the default columns. This PR forwards `options.columns` in both task-creation calls so collection helpers honor the same layout option as `Progress.task`.

For example:

```ts
import { Effect } from "effect";
import * as Progress from "effective-progress";

const options = {
  description: "Upload files",
  columns: [{ render: () => "CUSTOM_COLLECTION_COLUMN" }],
};

const program = Progress.all([Effect.void], options);
// The same issue applies to:
// Progress.forEach([1], () => Effect.void, options);

Effect.runPromise(program);
```

Before this change, the output contains the default description, bar, counts, and elapsed/ETA columns; `CUSTOM_COLLECTION_COLUMN` never appears. Afterward, the requested custom column appears. Passing the same options to `Progress.task` already worked, which made the collection-helper behavior especially surprising.

The fix adds one forwarded property to each helper. Task totals, count-display selection, concurrency, and lifecycle handling continue to use their existing logic. Omitting `columns` still lets the renderer select its defaults.

Validation: added a parameterized integration test covering both helpers using captured non-TTY Ink output. Both cases were run before the production change and failed with the default layout instead of the custom marker; both pass after the fix. `bun run format`, `bun run check` (typecheck, lint, formatting, Knip), and the complete `bun test` suite pass: **110 tests, 0 failures**.
