### PR TITLE
fix: infer string totals from Unicode iteration items

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,8 @@ export const inferTotal = (iterable: Iterable<unknown>): number | undefined => {
   }
 
   if (typeof iterable === "string") {
-    return iterable.length;
+    // String iteration yields Unicode code points, not UTF-16 code units.
+    return [...iterable].length;
   }
 
   const candidate = iterable as { length?: unknown; size?: unknown };

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { inferTotal } from "../src/utils";
+
+describe("inferTotal", () => {
+  test.each([
+    ["", 0],
+    ["abc", 3],
+    ["你好", 2],
+    ["a😀", 2],
+    ["😀🚀", 2],
+    ["e\u0301", 2],
+    ["👩‍💻", 3],
+  ] as const)("counts string iteration items for %j", (input, expected) => {
+    expect(inferTotal(input)).toBe(expected);
+  });
+});


### PR DESCRIPTION
`inferTotal` used JavaScript string `.length` as the number of items that `Progress.forEach` would process. String length measures UTF-16 code units, while string iteration yields Unicode code points. Characters outside the Basic Multilingual Plane, including many emoji, therefore inflated the progress total.

For example:

```ts
import { Effect } from "effect";
import * as Progress from "effective-progress";

const program = Progress.forEach(
  "a😀",
  (character) => Effect.succeed(character),
  { description: "Process characters" },
);

Effect.runPromise(program); // Processes exactly two items: "a" and "😀".
```

Before this change, the inferred total is 3 despite there being only two callback invocations. That can leave the running task at `2/3`; normal completion also fills remaining work as success, masking the inaccurate item count. Afterward, the total is 2 and agrees with the iterable.

The string branch now returns `[...iterable].length`, with a comment explaining why `.length` is insufficient. This deliberately counts iteration items: a combining mark or a zero-width joiner remains a separate code point, even when several code points form one visible glyph.

| Input | Old inferred total | New inferred total / iteration count |
| --- | ---: | ---: |
| `abc` | 3 | 3 |
| `a😀` | 3 | 2 |
| `😀🚀` | 4 | 2 |
| `👩‍💻` | 5 | 3 |

The change is confined to strings; arrays, size/length-bearing iterables, and unknown-size iterables retain their existing paths. String inference now takes linear time and allocates a temporary code-point array.

Validation: seven focused cases cover empty strings, ASCII, BMP characters, astral characters, combining marks, and a joined emoji sequence. The three astral-character cases failed before the fix and pass afterward. Formatting and `bun run check` pass; the complete test suite passes with **115 tests, 0 failures**.
