### PR TITLE
refactor: reuse the shared determinate task guard

### DIFF
--- a/src/services/renderer/columns/description-column.tsx
+++ b/src/services/renderer/columns/description-column.tsx
@@ -4,6 +4,7 @@ import { useRef } from "react";
 import type { CellInfo, TaskSnapshot } from "../../../types";
 import { useSpinnerTick } from "../context/spinner-context";
 import type { TaskRowModel } from "../../store/types";
+import { isDeterminate } from "../shared/determinate";
 
 const MIN_TREE_DESCRIPTION_TEXT_WIDTH = 6;
 type TaskIndicatorColor = "green" | "yellow" | "red";
@@ -14,11 +15,6 @@ interface TaskIndicator {
 }
 
 const DEFAULT_SPINNER_TYPE: SpinnerName = "dots";
-
-const isDeterminate = (
-  task: TaskSnapshot,
-): task is TaskSnapshot & { readonly units: TaskSnapshot["units"] & { readonly total: number } } =>
-  task.units.total !== undefined;
 
 const getSpinnerFrame = (tick: number, spinnerType: SpinnerName): string => {
   const frames = cliSpinners[spinnerType].frames;

--- a/src/services/renderer/shared/format.ts
+++ b/src/services/renderer/shared/format.ts
@@ -1,9 +1,5 @@
 import type { TaskSnapshot } from "../../../types";
-
-const isDeterminate = (
-  task: TaskSnapshot,
-): task is TaskSnapshot & { readonly units: TaskSnapshot["units"] & { readonly total: number } } =>
-  task.units.total !== undefined;
+import { isDeterminate } from "./determinate";
 
 const showsUnknownTotalCounts = (task: TaskSnapshot): boolean =>
   task.units.total === undefined && task.units.processed > 0;


### PR DESCRIPTION
The renderer had three identical implementations of `isDeterminate`: the shared helper in `shared/determinate.ts`, a private copy in `shared/format.ts`, and another private copy in the description column. The bar and amount columns already imported the shared helper. Maintaining separate predicates and type guards makes a future definition change easy to apply inconsistently across columns.

This PR removes the two private copies and imports the existing helper. Its implementation and TypeScript predicate remain unchanged:

```ts
const isDeterminate = (
  task: TaskSnapshot,
): task is TaskSnapshot & {
  readonly units: TaskSnapshot["units"] & { readonly total: number };
} => task.units.total !== undefined;
```

For example, all affected callers continue to distinguish these cases in the same way:

| Task total | Determinate? | Meaning |
| --- | --- | --- |
| `undefined` | No | The task has no known total |
| `0` | Yes | An empty, known-size task is still determinate |
| `10` | Yes | The task has a known total of ten |

Within `if (isDeterminate(task))`, TypeScript still narrows `task.units.total` to `number`. Reusing the predicate preserves both runtime behavior and that narrowing without introducing a new abstraction or changing the public API.

The practical maintenance improvement is that formatting, task indicators, bars, and amounts now consult the same helper. In particular, this preserves the intentional distinction between an absent total and a zero total; it does not replace the predicate with a truthiness check.

Validation: `bun run format` and `bun run check` pass, including typechecking of the imported guard at its call sites. The complete existing suite passes with **108 tests, 0 failures**, including zero-total rendering, unknown-total counts, overflow formatting, and task indicators. No new tests were added for an import-only refactor.
