### PR TITLE
refactor: share the ETA formatting implementation

### DIFF
--- a/src/services/renderer/shared/format.ts
+++ b/src/services/renderer/shared/format.ts
@@ -79,24 +79,7 @@ const formatElapsedClock = (task: TaskSnapshot, now: number): string => {
   return formatClockDurationSeconds(elapsedMillis / 1000);
 };
 
-export const formatEta = (task: TaskSnapshot): string => {
-  if (task.status !== "running" || !isDeterminate(task)) {
-    return "";
-  }
-
-  const { processed, total } = task.units;
-  const remaining = total - processed;
-  if (processed <= 0 || remaining <= 0) {
-    return "";
-  }
-
-  const etaMillis = getSmoothedEtaMillis(task);
-  if (etaMillis === undefined) {
-    return "";
-  }
-
-  return formatClockDurationSeconds(etaMillis / 1000);
-};
+export const formatEta = (task: TaskSnapshot): string => formatEtaClock(task) ?? "";
 
 const formatEtaClock = (task: TaskSnapshot): string | undefined => {
   if (task.status !== "running" || !isDeterminate(task)) {


### PR DESCRIPTION
`formatEta` and `formatEtaClock` implemented the same ETA calculation independently. Both checked task status and total availability, checked that progress and remaining work were positive, called the smoothed ETA estimator, and formatted the result as a clock. Their only behavioral difference was how they represented an unavailable estimate: `formatEta` returned an empty string, while `formatEtaClock` returned `undefined`.

This PR keeps the optional formatter as the single implementation and turns the public formatter into a small adapter:

```ts
export const formatEta = (task: TaskSnapshot): string =>
  formatEtaClock(task) ?? "";
```

The combined elapsed/ETA formatter continues to use the same optional result with its own fallback:

```ts
`${formatElapsedClock(task, now)}<${formatEtaClock(task) ?? "00:00"}`
```

For a running task that has processed 2 of 10 items over a sampled interval of 2 seconds, the estimate is 8 seconds. With 2 seconds elapsed, these results remain identical before and after the refactor:

| Situation | Standalone `formatEta` | Combined elapsed/ETA |
| --- | --- | --- |
| The example above | `00:08` | `00:02<00:08` |
| No usable estimate, 2 seconds elapsed | Empty string | `00:02<00:00` |

Keeping the missing-value distinction at the call sites matters: an unavailable standalone ETA should disappear, while the compact combined column retains its clock-shaped placeholder. The shared implementation preserves that distinction and prevents the two displays from drifting when ETA rules change.

Validation: formatting and `bun run check` pass. The complete existing test suite passes with **108 tests, 0 failures**, including ETA sample-based estimates, empty/unavailable estimates, combined elapsed/ETA output, and long clock durations. No estimator, sampling, or output-format behavior changes are introduced.
