### PR TITLE
refactor: simplify the private scopedTask signature

### DIFF
--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -6,24 +6,6 @@ import { Task } from "../types";
 import { Renderer } from "./renderer/renderer";
 import { ProgressStdio } from "./stdio";
 
-interface InternalTaskApi {
-  <A, E, R>(
-    effect: Effect.Effect<A, E, R>,
-    options: AddTaskOptions,
-  ): Effect.Effect<A, E, Exclude<R, Task>>;
-  <A, E, R>(
-    options: AddTaskOptions,
-  ): (effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Task>>;
-  <A, E, R>(
-    f: (handle: TaskHandle<void>) => Effect.Effect<A, E, R>,
-    options: AddTaskOptions<void>,
-  ): Effect.Effect<A, E, Exclude<R, Task>>;
-  <M, A, E, R>(
-    f: (handle: TaskHandle<M>) => Effect.Effect<A, E, R>,
-    options: AddTaskOptions<M> & { readonly metadata: M },
-  ): Effect.Effect<A, E, Exclude<R, Task>>;
-}
-
 interface CurrentParentState {
   readonly owner: symbol;
   readonly taskId: TaskId;
@@ -98,7 +80,7 @@ const makeProgressService = Effect.gen(function* () {
       }
     });
 
-  const scopedTask = dual(2, <A, E, R>(effect: Effect.Effect<A, E, R>, options: AddTaskOptions) =>
+  const scopedTask = <A, E, R>(effect: Effect.Effect<A, E, R>, options: AddTaskOptions) =>
     Effect.gen(function* () {
       const inheritedParentId = yield* currentParentId;
       const resolvedParentId =
@@ -115,8 +97,7 @@ const makeProgressService = Effect.gen(function* () {
         CurrentParent,
         Option.some({ owner: parentOwner, taskId }),
       );
-    }),
-  ) as InternalTaskApi;
+    });
 
   const task: ProgressShape["task"] = dual(
     2,


### PR DESCRIPTION
The private `scopedTask` helper was wrapped in `dual(2, ...)` and cast to an `InternalTaskApi` interface containing direct, curried, and typed-callback overloads. Its implementation only accepts an Effect, and its two internal call sites both supply that Effect and the options directly. The callback overloads on the asserted interface described behavior this helper did not implement.

This PR makes `scopedTask` a plain generic function and removes the unused overload interface and assertion. TypeScript now infers the helper's result from its actual implementation, including the provision of the `Task` service.

The internal call pattern is unchanged:

```ts
scopedTask(effect, options);
```

Previously the cast also advertised a call like this as valid inside the module, even though callback handling belongs to the outer `task` implementation:

```ts
scopedTask((handle) => handle.complete, { description: "Deploy" });
```

The plain function signature no longer claims to accept that callback. The outer `task` implementation still turns callbacks into Effects before invoking the helper.

All supported public forms remain available, for example:

```ts
Progress.task(Effect.void, { description: "Direct" });
Effect.void.pipe(Progress.task({ description: "Piped" }));
Progress.task((handle) => handle.complete, { description: "Callback" });
```

The helper still creates the task and provides both its task ID and parent context to the wrapped Effect. Public overloads, `dual` handling at the actual public/service entry points, typed metadata, and automatic finalization remain in place.

Validation: `bun run format` and `bun run check` pass, so the inferred helper type satisfies both internal callers and the declared service API. All **108 existing tests pass**, including nested task/service behavior, collection pipe forms, typed callbacks with explicit completion/failure, and terminal finalization. This PR changes only the private helper's representation.
