### PR TITLE
refactor: resolve task parents in addTask once

### DIFF
--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -100,15 +100,7 @@ const makeProgressService = Effect.gen(function* () {
 
   const scopedTask = dual(2, <A, E, R>(effect: Effect.Effect<A, E, R>, options: AddTaskOptions) =>
     Effect.gen(function* () {
-      const inheritedParentId = yield* currentParentId;
-      const resolvedParentId =
-        options.parentId === undefined ? inheritedParentId : Option.some(options.parentId);
-
-      const taskId = yield* addTask({
-        ...options,
-        parentId: Option.isSome(resolvedParentId) ? resolvedParentId.value : undefined,
-        transient: options.transient,
-      });
+      const taskId = yield* addTask(options);
 
       return yield* Effect.provideService(
         Effect.provideService(effect, Task, taskId),


### PR DESCRIPTION
`scopedTask` duplicated the parent-resolution logic already implemented by the service's `addTask` helper. It read the inherited parent, preferred an explicit `options.parentId`, copied the options into another object, and then called `addTask`, which applied the same parent-selection rule again. It also reassigned `transient` to the value already present in the spread options.

This PR replaces that block with:

```ts
const taskId = yield* addTask(options);
```

`addTask` remains the single place that chooses between an explicit parent and the current inherited parent. Its existing ownership check still ignores inherited IDs from another Progress service, whose task IDs belong to a different store.

For example, ordinary nesting continues to work without an explicit ID:

```ts
Progress.task(
  Progress.task(Effect.void, { description: "Child" }),
  { description: "Parent" },
);
```

The child is created under the parent in both versions. For lower-level callers that provide an explicit parent, the same precedence also remains:

```ts
// Inside an Effect with a Progress service:
const progress = yield* Progress.Progress;
const parentId = yield* progress.addTask({ description: "Explicit parent" });
yield* progress.task(Effect.void, { description: "Child", parentId });
```

A root task still has no inherited parent; an isolated nested Progress layer still does not attach its tasks to IDs in the outer store. Description, metadata, columns, transient settings, and all other options reach `addTask` directly instead of being copied by `scopedTask` first.

This is a contained cleanup of duplicated policy. Task creation and context provision remain in the same order, with parent selection owned by the helper that actually creates the task.

Validation: formatting and `bun run check` pass. All **108 existing tests pass**, including nested task rendering, isolated nested service ownership, parent/child transient propagation, and inherited count display. No lifecycle or public API changes are introduced.
