### PR TITLE
refactor: share succeeded and failed counter updates

### DIFF
--- a/src/services/store/store.ts
+++ b/src/services/store/store.ts
@@ -318,6 +318,43 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
     return publish(transform(state), now);
   };
 
+  const incrementCounter = (taskId: TaskId, kind: "succeeded" | "failed", amount: number) =>
+    Effect.gen(function* () {
+      const now = yield* Clock.currentTimeMillis;
+
+      yield* updateState((current) => {
+        const currentTask = current.tasks.get(taskId);
+        if (!currentTask) {
+          return { state: current, events: [] };
+        }
+
+        const units = normalizeUnits({
+          succeeded: currentTask.units.succeeded,
+          failed: currentTask.units.failed,
+          [kind]: currentTask.units[kind] + amount,
+          total: currentTask.units.total,
+        });
+        const nextTasks = new Map(current.tasks);
+        nextTasks.set(
+          taskId,
+          TaskSnapshot({
+            ...currentTask,
+            units,
+            progressSamples: appendProgressSample(
+              currentTask.progressSamples,
+              now,
+              units.processed,
+            ),
+          }),
+        );
+
+        return {
+          state: { tasks: nextTasks, renderOrder: current.renderOrder, columns: current.columns },
+          events: [new TaskAdvancedEvent({ taskId, amount, kind })],
+        };
+      }, now);
+    });
+
   const store: ProgressStoreShape = {
     getSnapshot: () => publishedPublication,
     subscribe: (listener) => {
@@ -444,76 +481,8 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
           };
         }, now);
       }),
-    incrementSucceeded: (taskId, amount = 1) =>
-      Effect.gen(function* () {
-        const now = yield* Clock.currentTimeMillis;
-
-        yield* updateState((current) => {
-          const currentTask = current.tasks.get(taskId);
-          if (!currentTask) {
-            return { state: current, events: [] };
-          }
-
-          const units = normalizeUnits({
-            succeeded: currentTask.units.succeeded + amount,
-            failed: currentTask.units.failed,
-            total: currentTask.units.total,
-          });
-          const nextTasks = new Map(current.tasks);
-          nextTasks.set(
-            taskId,
-            TaskSnapshot({
-              ...currentTask,
-              units,
-              progressSamples: appendProgressSample(
-                currentTask.progressSamples,
-                now,
-                units.processed,
-              ),
-            }),
-          );
-
-          return {
-            state: { tasks: nextTasks, renderOrder: current.renderOrder, columns: current.columns },
-            events: [new TaskAdvancedEvent({ taskId, amount, kind: "succeeded" })],
-          };
-        }, now);
-      }),
-    incrementFailed: (taskId, amount = 1) =>
-      Effect.gen(function* () {
-        const now = yield* Clock.currentTimeMillis;
-
-        yield* updateState((current) => {
-          const currentTask = current.tasks.get(taskId);
-          if (!currentTask) {
-            return { state: current, events: [] };
-          }
-
-          const units = normalizeUnits({
-            succeeded: currentTask.units.succeeded,
-            failed: currentTask.units.failed + amount,
-            total: currentTask.units.total,
-          });
-          const nextTasks = new Map(current.tasks);
-          nextTasks.set(
-            taskId,
-            TaskSnapshot({
-              ...currentTask,
-              units,
-              progressSamples: appendProgressSample(
-                currentTask.progressSamples,
-                now,
-                units.processed,
-              ),
-            }),
-          );
-
-          return {
-            state: { tasks: nextTasks, renderOrder: current.renderOrder, columns: current.columns },
-            events: [new TaskAdvancedEvent({ taskId, amount, kind: "failed" })],
-          };
-        }, now);
-      }),
+    incrementSucceeded: (taskId, amount = 1) => incrementCounter(taskId, "succeeded", amount),
+    incrementFailed: (taskId, amount = 1) => incrementCounter(taskId, "failed", amount),
     completeTask: (taskId) =>
       Effect.gen(function* () {
         const now = yield* Clock.currentTimeMillis;


### PR DESCRIPTION
`incrementSucceeded` and `incrementFailed` each contained a full copy of the same store-update sequence: obtain the time, find the task, normalize its counters, copy the task map, append a progress sample, and publish a `TaskAdvanced` event. Only the counter selected for the addition and the event's `kind` differed. Changes to sampling or publication therefore had to be kept synchronized across two implementations.

This PR extracts a private `incrementCounter(taskId, kind, amount)` helper, where `kind` is restricted to `"succeeded" | "failed"`. The existing methods keep their names, signatures, and default increment of one:

```ts
incrementSucceeded: (taskId, amount = 1) =>
  incrementCounter(taskId, "succeeded", amount),
incrementFailed: (taskId, amount = 1) =>
  incrementCounter(taskId, "failed", amount),
```

The helper starts from both current counters and updates the selected field using a computed property. The same `kind` also populates the event, so counter selection and event labeling are handled together without casts or an unrestricted string parameter.

For example, these low-level calls retain their existing results:

```ts
yield* progress.incrementSucceeded(taskId, 2);
yield* progress.incrementFailed(taskId);
```

Starting from zero counts and a total of 5, the resulting units are `{ succeeded: 2, failed: 1, processed: 3, total: 5 }`. The corresponding advanced events still contain `{ amount: 2, kind: "succeeded" }` and `{ amount: 1, kind: "failed" }`.

Existing edge behavior stays inside the shared path: missing task IDs produce no state update; normalization clamps negative resulting counts; raw counts may exceed the total; samples track processed-count changes; publication continues through the existing batching mechanism. Completion and failure lifecycle methods are untouched.

Validation: formatting and `bun run check` pass. All **108 existing tests pass**, including concrete succeeded/failed event payloads, overflow counts, indeterminate counts, sample retention, publication coalescing, and terminal behavior. The extraction removes duplicated implementation without changing the store interface.
