### PR TITLE
refactor: replace obsolete renderer and task test names

### DIFF
--- a/src/services/renderer/renderer.tsx
+++ b/src/services/renderer/renderer.tsx
@@ -25,7 +25,7 @@ const ProgressRoot = ({ store }: { readonly store: ProgressStoreShape }) => {
   );
 };
 
-const makeRendererv2InkRendererService = Effect.gen(function* () {
+const makeRendererService = Effect.gen(function* () {
   const store = yield* ProgressStore;
   const stdio = yield* ProgressStdio;
   const proot = <ProgressRoot store={store} />;
@@ -61,5 +61,5 @@ const makeRendererv2InkRendererService = Effect.gen(function* () {
 export class Renderer extends Context.Service<Renderer, RendererShape>()(
   "stromseng.dev/effective-progress/Renderer",
 ) {
-  static readonly layer = Layer.effect(Renderer, makeRendererv2InkRendererService);
+  static readonly layer = Layer.effect(Renderer, makeRendererService);
 }

--- a/tests/renderer-description-column.test.tsx
+++ b/tests/renderer-description-column.test.tsx
@@ -73,7 +73,7 @@ const renderDescriptionColumn = (rows: ReadonlyArray<TaskRowModel>, spinnerTick?
     ),
   );
 
-describe("rendererv2 description tree planning", () => {
+describe("renderer description tree planning", () => {
   test("renders the spinner after the tree prefix", () => {
     const rows = [
       deriveRow(makeTask(1, "root", "running"), {

--- a/tests/renderer-eta-column.test.tsx
+++ b/tests/renderer-eta-column.test.tsx
@@ -69,7 +69,7 @@ const renderTaskWithEta = (task: Progress.TaskSnapshot, now: number): string =>
 
 const renderWithEta = (now: number): string => renderTaskWithEta(makeTask(), now);
 
-describe("rendererv2 eta column", () => {
+describe("renderer eta column", () => {
   test("renders prefixed eta when task has progress", () => {
     const output = renderWithEta(1_000);
     expect(output).toContain("ETA: 00:01");

--- a/tests/renderer-progress-columns.test.tsx
+++ b/tests/renderer-progress-columns.test.tsx
@@ -59,7 +59,7 @@ const renderColumns = (rows: ReadonlyArray<TaskRowModel>): string =>
     ),
   );
 
-describe("rendererv2 progress columns", () => {
+describe("renderer progress columns", () => {
   test("renders amount values for all rows", () => {
     const output = renderColumns([
       deriveRow(

--- a/tests/renderer-public-api.test.tsx
+++ b/tests/renderer-public-api.test.tsx
@@ -70,7 +70,7 @@ const renderWithColumns = (
     ),
   );
 
-describe("rendererv2 public api", () => {
+describe("renderer public api", () => {
   test("renders null when there are no rows", () => {
     const output = renderWithColumns([], new Map());
     expect(output).toBe("");

--- a/tests/renderer-rows.test.tsx
+++ b/tests/renderer-rows.test.tsx
@@ -59,7 +59,7 @@ const renderRows = (rows: ReadonlyArray<TaskRowModel>): string =>
     ),
   ).trimEnd();
 
-describe("rendererv2 row rendering", () => {
+describe("renderer row rendering", () => {
   test("renders all rows directly without virtual scrolling", () => {
     const rows = Array.from({ length: 12 }, (_, index) => deriveRow(makeTask(index + 1)));
     const output = renderRows(rows);

--- a/tests/task-scopes.test.ts
+++ b/tests/task-scopes.test.ts
@@ -44,7 +44,7 @@ const getTaskByDescription = (
   return task!;
 };
 
-describe("Progress.run", () => {
+describe("Progress task scopes", () => {
   test("plain logs are not swallowed when no tasks are created", async () => {
     const message = "plain-log-no-task";
     const { logs } = await Effect.runPromise(withLogSpy(withStdio(Console.log(message))));
@@ -52,7 +52,7 @@ describe("Progress.run", () => {
     expect(logs.some((args) => args[0] === message)).toBeTrue();
   });
 
-  test("nested run reuses the outer service", async () => {
+  test("nested task reuses the outer service", async () => {
     const reused = await Effect.runPromise(
       withStdio(
         Progress.task(


### PR DESCRIPTION
Several internal and test names still described the previous renderer migration or a removed `Progress.run` API. The renderer factory was named `makeRendererv2InkRendererService`; renderer test files and suites used `rendererv2`; and `run.test.ts` reported its suite as `Progress.run` even though it exercises task scopes and collection helpers. Those names make code search and test failures harder to connect to the current API.

This PR updates the names to describe the current code:

| Before | After |
| --- | --- |
| `makeRendererv2InkRendererService` | `makeRendererService` |
| `rendererv2-description-column.test.tsx` | `renderer-description-column.test.tsx` |
| `rendererv2-eta-column.test.tsx` | `renderer-eta-column.test.tsx` |
| `rendererv2-progress-columns.test.tsx` | `renderer-progress-columns.test.tsx` |
| `rendererv2-public-api.test.tsx` | `renderer-public-api.test.tsx` |
| `rendererv2-virtual-list.test.tsx` | `renderer-rows.test.tsx` |
| `run.test.ts` | `task-scopes.test.ts` |

The virtual-list filename becomes `renderer-rows` because its test exercises row rendering; the old filename implied a separate virtual-list implementation. Renderer suite labels likewise use `renderer`, and the task suite becomes `Progress task scopes`.

For example, a previously reported test name was:

```text
Progress.run > nested run reuses the outer service
```

It now reads:

```text
Progress task scopes > nested task reuses the outer service
```

This aligns the output with the nested `Progress.task` calls in the test. The implementation, assertions, public exports, and service context identifiers are unchanged. The factory's declaration and layer reference are renamed together; Git recognizes the test moves as renames with small label edits.

Validation: `bun run format` and `bun run check` pass. Bun discovers all renamed files and the complete suite still passes with **108 tests, 0 failures**. The existing CI command is `bun test`, so it requires no filename-specific update. This PR is solely a naming and developer-experience cleanup.
