### PR TITLE
fix: treat non-finite task totals as unknown

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ const program = Progress.task(
 
 Manual total behavior:
 
-- negative totals on task creation clear the total and switch to indeterminate rendering
-- negative totals on later `updateTask` calls also clear the total
+- negative or non-finite totals (`NaN`, `Infinity`, `-Infinity`) on task creation clear the total and switch to indeterminate rendering
+- negative or non-finite totals on later `updateTask` calls also clear the total
 - explicit `total: undefined` on `updateTask` clears the total and switches back to indeterminate rendering
 
 ## Typed metadata and custom columns

--- a/src/services/store/store.ts
+++ b/src/services/store/store.ts
@@ -56,7 +56,7 @@ const sanitizeTotal = (total: number | undefined) => {
     return undefined;
   }
 
-  return total < 0 ? undefined : total;
+  return !Number.isFinite(total) || total < 0 ? undefined : total;
 };
 
 const normalizeUnits = (counts: TaskCounts) => {

--- a/tests/ink-renderer-store.test.ts
+++ b/tests/ink-renderer-store.test.ts
@@ -5,6 +5,41 @@ import type { ColumnDef } from "../src";
 import { makeProgressStore } from "../src/services/store/store";
 
 describe("progress render store", () => {
+  test.each([[NaN], [Infinity], [-Infinity]] as const)(
+    "clears non-finite total %s on creation",
+    async (total) => {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const store = yield* makeProgressStore;
+          const taskId = yield* store.addTask({ description: "non-finite", total });
+          const task = Option.getOrThrow(yield* store.getTask(taskId));
+
+          expect(task.units.total).toBeUndefined();
+          expect(task.units.processed).toBe(0);
+        }).pipe(Effect.scoped),
+      );
+    },
+  );
+
+  test.each([[NaN], [Infinity], [-Infinity]] as const)(
+    "clears non-finite total %s on update",
+    async (total) => {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const store = yield* makeProgressStore;
+          const taskId = yield* store.addTask({ description: "non-finite", total: 5 });
+          yield* store.incrementSucceeded(taskId, 2);
+          yield* store.incrementFailed(taskId);
+          yield* store.updateTask(taskId, { total });
+          const task = Option.getOrThrow(yield* store.getTask(taskId));
+
+          expect(task.units.total).toBeUndefined();
+          expect(task.units).toMatchObject({ succeeded: 2, failed: 1, processed: 3 });
+        }).pipe(Effect.scoped),
+      );
+    },
+  );
+
   test("stops pending publications when the store scope closes", async () => {
     await Effect.runPromise(
       Effect.gen(function* () {


### PR DESCRIPTION
Task creation and updates allowed `NaN` and positive `Infinity` to enter the store as known totals. `sanitizeTotal` only rejected negative values, so `NaN < 0` and `Infinity < 0` both bypassed the guard. The renderer then treated those values as determinate totals, producing counts such as `1/NaN` and, with usable progress samples, an ETA of `NaN:NaN`.

This PR adds `Number.isFinite` to the existing total normalization. Non-finite totals become `undefined`, using the same unknown-total behavior already applied to negative totals. The README now documents the rule for both creation and later updates.

For example, inside an Effect with a Progress service:

```ts
const progress = yield* Progress.Progress;
const id = yield* progress.addTask({
  description: "Download",
  total: Number("unknown"), // NaN
  countDisplay: "processedOnly",
});
yield* progress.incrementSucceeded(id);
```

Before this change, the running task has a total of `NaN` and its amount text is `1/NaN`. Afterward, it has no known total and displays `1/?`; the standalone ETA is unavailable until there is a usable known total.

Updating an existing task behaves consistently:

```ts
yield* progress.updateTask(id, { total: Infinity });
```

The update now clears the total while preserving succeeded, failed, and processed counts. Zero and finite nonnegative totals remain valid. Negative infinity was already cleared by the negative-value rule and continues to be handled correctly. The change concerns totals; it does not alter normalization of increment amounts or manually supplied counters.

Validation: added six focused store cases covering `NaN`, `Infinity`, and `-Infinity` on creation and update. The four NaN/positive-infinity cases failed before the fix; all six pass afterward. Update cases also verify that accumulated counts survive. `bun run format`, `bun run check` (typecheck, lint, formatting, Knip), and the complete test suite pass: **123 tests, 0 failures**.
