### PR TITLE
refactor: preserve types through tracked effects

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -118,10 +118,10 @@ const isCollectAllMode = (mode: EffectAllExecutionOptions["mode"]) => mode === "
 const allCountDisplay = (mode: EffectAllExecutionOptions["mode"]): TaskCountDisplay =>
   isCollectAllMode(mode) ? "detailed" : "processedOnly";
 
-const wrapTrackedEffect = (
+const wrapTrackedEffect = <A, E, R>(
   progress: ProgressShape,
   taskId: TaskId,
-  effect: Effect.Effect<any, any, any>,
+  effect: Effect.Effect<A, E, R>,
 ) =>
   Effect.gen(function* () {
     const exit = yield* Effect.exit(effect);
@@ -274,5 +274,5 @@ export const forEach: {
           },
         );
       }),
-    ) as Effect.Effect<ReadonlyArray<B>, E, Exclude<R, Progress | Task>>,
+    ),
 );


### PR DESCRIPTION
`wrapTrackedEffect` accepted `Effect.Effect<any, any, any>`, erasing the wrapped Effect's success value, error, and required services inside the tracking implementation. The public `forEach` signature was typed, but its implementation ended in an assertion restoring the advertised return type. That assertion could hide a future mismatch between the implementation and its contract.

This PR makes the helper generic over all three Effect parameters and removes the now-unnecessary assertion from `forEach`:

```ts
// Before:
const wrapTrackedEffect = (
  progress: ProgressShape,
  taskId: TaskId,
  effect: Effect.Effect<any, any, any>,
) => /* track the exit */;

// After:
const wrapTrackedEffect = <A, E, R>(
  progress: ProgressShape,
  taskId: TaskId,
  effect: Effect.Effect<A, E, R>,
) => /* the same implementation */;
```

For an input `Effect.Effect<User, FetchError, ApiClient>`, the helper now preserves `User`, `FetchError`, and `ApiClient` in its inferred result. Its counter updates require no additional services because it receives the Progress service instance directly.

For example, the collection API can carry those types through a program like:

```ts
const program = Progress.forEach(
  userIds,
  (id) => fetchUser(id), // Effect<User, FetchError, ApiClient>
  { description: "Fetch users" },
);
// Effect<ReadonlyArray<User>, FetchError, ApiClient>
```

That public contract already existed; the improvement is that TypeScript now verifies the implementation reaches it through inference rather than a final cast. Success/failure counting, interruption handling, concurrency, and task lifecycle logic are unchanged. The heterogeneous `all` machinery is outside this small refactor.

Validation: formatting and `bun run check` pass with the `forEach` assertion removed. All **117 existing tests pass**, including collection results, pipe forms, fail-fast behavior, and mixed outcome counters. No runtime behavior changes are introduced.
