### PR TITLE
refactor: expose task snapshot maps as read-only

### DIFF
--- a/examples/benchmarks.ts
+++ b/examples/benchmarks.ts
@@ -67,7 +67,11 @@ const benchmarkStore = (taskCount: number) =>
   }).pipe(Effect.scoped);
 
 const makeColumnFixture = (rowCount: number, distinctPrepare: boolean) => {
-  const store: TaskStore = { tasks: new Map(), renderOrder: [], columns: new Map() };
+  const store = {
+    tasks: new Map<TaskId, TaskSnapshot>(),
+    renderOrder: [],
+    columns: new Map<TaskId, ReadonlyArray<ColumnDef<unknown, number>>>(),
+  } satisfies TaskStore;
   const renderOrder: Array<TaskStore["renderOrder"][number]> = [];
 
   for (let index = 0; index < rowCount; index++) {

--- a/src/services/renderer/column-resolver.ts
+++ b/src/services/renderer/column-resolver.ts
@@ -24,7 +24,7 @@ const DEFAULT_COLUMNS = defaults();
 
 const getColumnsForRow = (
   row: TaskRowModel,
-  columns: Map<TaskId, ReadonlyArray<ColumnDef<any, any>>>,
+  columns: ReadonlyMap<TaskId, ReadonlyArray<ColumnDef<any, any>>>,
 ): ReadonlyArray<ColumnDef<any, any>> => columns.get(row.task.id) ?? DEFAULT_COLUMNS;
 
 const toCellInfo = (row: TaskRowModel): CellInfo<unknown> => row;
@@ -72,7 +72,7 @@ const resolvePreparedGroups = (
 
 export const resolveColumns = (
   rows: ReadonlyArray<TaskRowModel>,
-  columns: Map<TaskId, ReadonlyArray<ColumnDef<any, any>>>,
+  columns: ReadonlyMap<TaskId, ReadonlyArray<ColumnDef<any, any>>>,
 ): ReadonlyArray<ResolvedColumnPosition> => {
   const columnsByRow = rows.map((row) => getColumnsForRow(row, columns));
   const cellInfos = rows.map(toCellInfo);

--- a/src/services/renderer/public-api.tsx
+++ b/src/services/renderer/public-api.tsx
@@ -9,7 +9,7 @@ import type { TaskRowModel } from "../store/types";
 
 interface ProgressRendererProps {
   readonly rows: ReadonlyArray<TaskRowModel>;
-  readonly columns: Map<TaskId, ReadonlyArray<ColumnDef<any, any>>>;
+  readonly columns: ReadonlyMap<TaskId, ReadonlyArray<ColumnDef<any, any>>>;
 }
 
 const justifyContentForAlign = (align: ColumnAlign | undefined) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,9 +150,9 @@ export interface RenderRow {
 }
 
 export interface TaskStore {
-  readonly tasks: Map<TaskId, TaskSnapshot>;
+  readonly tasks: ReadonlyMap<TaskId, TaskSnapshot>;
   readonly renderOrder: ReadonlyArray<RenderRow>;
-  readonly columns: Map<TaskId, ReadonlyArray<ColumnDef<any, any>>>;
+  readonly columns: ReadonlyMap<TaskId, ReadonlyArray<ColumnDef<any, any>>>;
 }
 
 export interface ProgressShape {


### PR DESCRIPTION
`TaskStore` declared its map properties as `readonly`, but the map values themselves were mutable `Map` instances in the public type. That prevents replacing `snapshot.tasks`, yet still allows `snapshot.tasks.clear()` or `snapshot.columns.delete(id)`. Mutating a published snapshot this way bypasses the store's update, event, and notification paths.

This PR exposes `tasks` and `columns` through `ReadonlyMap` and changes the renderer's column inputs to accept the same read-only interface. Reads and iteration continue to work:

```ts
const task = snapshot.tasks.get(id);
const count = snapshot.tasks.size;
for (const [taskId, task] of snapshot.tasks) {
  // Inspect tasks.
}
```

Mutating through a `TaskStore` reference is now rejected by TypeScript:

```ts
// Previously accepted; now type errors:
snapshot.tasks.clear();
snapshot.columns.delete(id);
```

The store already constructs mutable copies with `new Map(current.tasks)` before applying changes, so its implementation needs no mutation workaround. Existing callers can still pass ordinary `Map` instances into the renderer because they satisfy `ReadonlyMap`.

The benchmark fixture intentionally builds maps incrementally. It now uses explicitly typed mutable maps and `satisfies TaskStore`, preserving `.set()` while it constructs the fixture without weakening the snapshot-facing type:

```ts
const store = {
  tasks: new Map<TaskId, TaskSnapshot>(),
  renderOrder: [],
  columns: new Map<TaskId, ReadonlyArray<ColumnDef<unknown, number>>>(),
} satisfies TaskStore;
```

This is compile-time protection, not runtime freezing. JavaScript callers or deliberate casts can still mutate the underlying objects. TypeScript consumers that directly mutated a `TaskStore` map will need to build a mutable map separately or use the service's update methods.

Validation: `bun run format` and `bun run check` pass, including the adjusted benchmark fixture and renderer signatures. All **117 existing tests pass**, covering store publication, column lookup, task updates, and rendering. No new runtime tests were added for this type-only change.
