### PR TITLE
refactor: remove redundant renderer conversions

### DIFF
--- a/src/services/renderer/column-resolver.ts
+++ b/src/services/renderer/column-resolver.ts
@@ -27,8 +27,6 @@ const getColumnsForRow = (
   columns: Map<TaskId, ReadonlyArray<ColumnDef<any, any>>>,
 ): ReadonlyArray<ColumnDef<any, any>> => columns.get(row.task.id) ?? DEFAULT_COLUMNS;
 
-const toCellInfo = (row: TaskRowModel): CellInfo<unknown> => row;
-
 const maxDefined = (values: ReadonlyArray<number | undefined>): number | undefined =>
   values.reduce<number | undefined>(
     (maxValue, value) =>
@@ -75,12 +73,11 @@ export const resolveColumns = (
   columns: Map<TaskId, ReadonlyArray<ColumnDef<any, any>>>,
 ): ReadonlyArray<ResolvedColumnPosition> => {
   const columnsByRow = rows.map((row) => getColumnsForRow(row, columns));
-  const cellInfos = rows.map(toCellInfo);
   const maxColumnCount = columnsByRow.reduce((max, defs) => Math.max(max, defs.length), 0);
 
   return Array.from({ length: maxColumnCount }, (_, index) => {
     const defsAtIndex = columnsByRow.map((defs) => defs[index]);
-    const preparedGroups = resolvePreparedGroups(defsAtIndex, cellInfos);
+    const preparedGroups = resolvePreparedGroups(defsAtIndex, rows);
     const entries = defsAtIndex.map((column) =>
       column === undefined
         ? undefined

--- a/src/services/renderer/columns/description-column.tsx
+++ b/src/services/renderer/columns/description-column.tsx
@@ -140,7 +140,7 @@ export const DescriptionColumn = ({ rows }: { readonly rows: ReadonlyArray<TaskR
   return (
     <Box ref={ref} flexDirection="column" flexShrink={1} flexBasis={preferredWidth} minWidth={1}>
       {rows.map((row) => (
-        <Box key={row.task.id as number} height={1}>
+        <Box key={row.task.id} height={1}>
           <DescriptionCell
             cell={row}
             width={hasMeasured ? width : undefined}

--- a/src/services/renderer/public-api.tsx
+++ b/src/services/renderer/public-api.tsx
@@ -54,15 +54,11 @@ const ColumnPosition = ({ position }: { readonly position: ResolvedColumnPositio
             width: hasMeasured ? width : position.flexBasis,
             now,
             spinnerTick,
-            prepared: entry?.prepared as never,
+            prepared: entry?.prepared,
           }) ?? null;
 
         return (
-          <Box
-            key={row.task.id as number}
-            height={1}
-            justifyContent={justifyContentForAlign(column?.align)}
-          >
+          <Box key={row.task.id} height={1} justifyContent={justifyContentForAlign(column?.align)}>
             <RenderedNode node={output} />
           </Box>
         );


### PR DESCRIPTION
Column resolution copied every row into a new array through an identity function named `toCellInfo`. The function returned its argument unchanged: `TaskRowModel` already structurally satisfies `CellInfo<unknown>`. The conversion therefore performed no transformation and allocated an unnecessary array on every resolution call.

This PR passes the existing rows directly to preparation grouping:

```ts
// Before:
const toCellInfo = (row: TaskRowModel): CellInfo<unknown> => row;
const cellInfos = rows.map(toCellInfo);
const preparedGroups = resolvePreparedGroups(defsAtIndex, cellInfos);

// After:
const preparedGroups = resolvePreparedGroups(defsAtIndex, rows);
```

For a thousand rows, the old path copied a thousand references into another array even though every entry was the same object. The new path uses the existing array. Preparation grouping still builds its own per-prepare-function row groups, so callbacks receive the same rows in the same order.

The PR also removes two kinds of unnecessary assertions at renderer call sites:

```tsx
// Before:
prepared: entry?.prepared as never
<Box key={row.task.id as number} ... />

// After:
prepared: entry?.prepared
<Box key={row.task.id} ... />
```

The prepared value is already accepted by the existing column render signature, and a branded numeric TaskId is already a valid React key. The `as never` assertion did not validate the prepared value or establish a stronger relationship between the column and its prepared type; removing it makes that boundary easier to read.

Validation: `bun run format` and `bun run check` pass with the mapping and assertions removed. All **117 existing tests pass**, including grouping prepared values by function, mixed positional columns, rendering missing cells, and nested description keys. This removes one redundant allocation and several assertions without changing layout or public contracts; no benchmark speedup is claimed.
