### PR TITLE
refactor: remove the unused amount formatter tick

### DIFF
--- a/src/services/renderer/columns/amount-column.tsx
+++ b/src/services/renderer/columns/amount-column.tsx
@@ -35,7 +35,7 @@ export const measureAmountLayout = (rows: ReadonlyArray<CellInfo<unknown>>): Amo
 
   if (countedTasks.length === 0) {
     const preferredWidth = rows.reduce(
-      (max, row) => Math.max(max, textWidth(formatAmount(row.task, 0))),
+      (max, row) => Math.max(max, textWidth(formatAmount(row.task))),
       0,
     );
 
@@ -74,7 +74,7 @@ export const measureAmountLayout = (rows: ReadonlyArray<CellInfo<unknown>>): Amo
       return Math.max(max, countedWidth);
     }
 
-    return Math.max(max, textWidth(formatAmount(row.task, 0)));
+    return Math.max(max, textWidth(formatAmount(row.task)));
   }, countedWidth);
 
   return {
@@ -94,7 +94,7 @@ const AmountValue = ({
   readonly layout: AmountLayout;
 }) => {
   if (!hasCountedAmount(task)) {
-    return formatAmount(task, 0);
+    return formatAmount(task);
   }
 
   const processed = `${task.units.processed}`.padStart(layout.processedWidth, " ");

--- a/src/services/renderer/shared/format.ts
+++ b/src/services/renderer/shared/format.ts
@@ -150,7 +150,7 @@ export const getDeterminateProcessedColor = (task: TaskSnapshot): DeterminatePro
   return "whiteBright";
 };
 
-export const formatAmount = (task: TaskSnapshot, _tick: number): string => {
+export const formatAmount = (task: TaskSnapshot): string => {
   if (isDeterminate(task)) {
     const parts = formatDeterminateAmountParts(task);
     if (parts === undefined) {

--- a/tests/ink-format.test.ts
+++ b/tests/ink-format.test.ts
@@ -126,7 +126,7 @@ describe("determinate amount formatting", () => {
       countDisplay: "processedOnly",
     });
 
-    expect(formatAmount(processedOnlyTask, 0)).toBe("4/4");
+    expect(formatAmount(processedOnlyTask)).toBe("4/4");
   });
 
   test("renders succeeded/failed and processed/total for detailed mode", () => {
@@ -140,7 +140,7 @@ describe("determinate amount formatting", () => {
       "done",
     );
 
-    expect(formatAmount(task, 0)).toBe("3 1 4/4");
+    expect(formatAmount(task)).toBe("3 1 4/4");
   });
 
   test("renders raw overflow counts for determinate tasks", () => {
@@ -154,7 +154,7 @@ describe("determinate amount formatting", () => {
       "done",
     );
 
-    expect(formatAmount(task, 0)).toBe("6 2 8/5");
+    expect(formatAmount(task)).toBe("6 2 8/5");
   });
 
   test("renders zero-total determinate counts as 0/0", () => {
@@ -171,7 +171,7 @@ describe("determinate amount formatting", () => {
       countDisplay: "processedOnly",
     });
 
-    expect(formatAmount(task, 0)).toBe("0/0");
+    expect(formatAmount(task)).toBe("0/0");
   });
 
   test("renders processed/? for counted indeterminate tasks", () => {
@@ -187,7 +187,7 @@ describe("determinate amount formatting", () => {
       countDisplay: "processedOnly",
     });
 
-    expect(formatAmount(task, 0)).toBe("4/?");
+    expect(formatAmount(task)).toBe("4/?");
   });
 
   test("renders succeeded/failed and processed/? for detailed indeterminate tasks", () => {
@@ -200,7 +200,7 @@ describe("determinate amount formatting", () => {
       "done",
     );
 
-    expect(formatAmount(task, 0)).toBe("3 1 4/?");
+    expect(formatAmount(task)).toBe("3 1 4/?");
   });
 });
 


### PR DESCRIPTION
`formatAmount` required a second `_tick` argument even though its implementation never read it. All callers passed a literal zero, making amount measurement and rendering look dependent on animation state when the output actually depends only on the task snapshot.

This PR removes that parameter and updates all three production call sites and the six direct formatting assertions:

```ts
// Before:
formatAmount(task, 0);

// After:
formatAmount(task);
```

The formatter's body is unchanged. For example, these outputs remain identical:

| Task state | Amount text |
| --- | --- |
| Processed-only, 4 processed of 4 | `4/4` |
| Detailed, 3 succeeded and 1 failed of 4 | `3 1 4/4` |
| Processed-only, 4 processed with unknown total | `4/?` |
| Detailed, 6 succeeded and 2 failed of 5 | `6 2 8/5` |
| Processed-only, empty known-size task | `0/0` |

The zero argument is removed from both layout measurement calls and the fallback text rendered by `AmountValue`. Keeping those call sites aligned with the real signature makes it clearer that formatting an amount requires no clock or spinner input.

`formatAmount` is an internal renderer helper and is not exported through the package's root entry point. The public column factories and spinner APIs are unchanged. The existing formatting tests keep the same assertions; only their calls lose the unused argument.

Validation: `bun run format`, `bun run check`, and all **117 existing tests pass**. The full typecheck confirms that no caller still supplies the removed parameter, and the unchanged expected strings verify that count formatting remains the same.
