### PR TITLE
refactor: reuse description layout preparation

### DIFF
--- a/src/services/renderer/columns/description-column.tsx
+++ b/src/services/renderer/columns/description-column.tsx
@@ -128,14 +128,7 @@ export const DescriptionColumn = ({ rows }: { readonly rows: ReadonlyArray<TaskR
   const { width, hasMeasured } = useBoxMetrics(ref);
   const spinnerTick = useSpinnerTick();
 
-  const minTreeWidth = rows.reduce(
-    (max, row) => Math.max(max, row.derived.treePrefixWidth + 2 + MIN_TREE_DESCRIPTION_TEXT_WIDTH),
-    MIN_TREE_DESCRIPTION_TEXT_WIDTH + 2,
-  );
-  const preferredWidth = rows.reduce(
-    (max, row) => Math.max(max, row.derived.treePrefixWidth + 2 + row.derived.descriptionWidth),
-    2,
-  );
+  const { minTreeWidth, preferredWidth } = prepareDescription(rows);
 
   return (
     <Box ref={ref} flexDirection="column" flexShrink={1} flexBasis={preferredWidth} minWidth={1}>


### PR DESCRIPTION
`DescriptionColumn` independently calculated `minTreeWidth` and `preferredWidth` using the same two reductions already implemented by `prepareDescription`. The shared preparation function is used by `Columns.description()`, while the standalone component is exercised by the description renderer tests. Keeping the calculations in both places makes future width-rule changes easy to apply inconsistently.

This PR replaces the duplicated reductions with the existing helper:

```ts
const { minTreeWidth, preferredWidth } = prepareDescription(rows);
```

The helper still reserves two cells for the indicator and separating space, adds the tree-prefix width, and uses the measured description width for the natural size. The minimum tree width still reserves six description cells. For example, for a single row:

| Row | Preferred width | Minimum width to show tree |
| --- | ---: | ---: |
| Root description `Download` (8 cells) | 10 | 8 |
| Description `Copy` (4 cells), prefix width 3 | 9 | 11 |
| Empty row list | 2 | 8 |

Those values are identical before and after the change. In the nested `Copy` example, a width below 11 still suppresses the tree prefix according to the existing `DescriptionCell` behavior; the refactor changes where the numbers come from, not the threshold.

The standalone component continues to measure its Ink box, read the spinner context, and render the same cells and keys. It simply obtains both layout values from the function that already owns those rules. No new helper, memoization, or API surface is introduced.

Validation: formatting and `bun run check` pass. All **117 existing tests pass**, including standalone description tree prefixes, spinner-context behavior, positional-column preparation, and narrow-terminal rendering. No new tests were added for replacing identical calculations with an existing helper.
