### PR TITLE
refactor: share subtree range detection

### DIFF
--- a/src/services/store/store.ts
+++ b/src/services/store/store.ts
@@ -156,42 +156,28 @@ const findInsertionIndex = (
   return { index: i, depth: parentDepth + 1 };
 };
 
-const removeFromRenderOrder = (
-  renderOrder: ReadonlyArray<TaskStore["renderOrder"][number]>,
-  taskId: TaskId,
-) => {
-  const idx = renderOrder.findIndex((row) => row.id === taskId);
-  if (idx === -1) {
-    return renderOrder;
+/** Finds the half-open range containing a task and all of its descendants. */
+const findSubtreeRange = (renderOrder: TaskStore["renderOrder"], taskId: TaskId) => {
+  const start = renderOrder.findIndex((row) => row.id === taskId);
+  if (start === -1) {
+    return undefined;
   }
 
-  const taskDepth = renderOrder[idx]!.depth;
-  let end = idx + 1;
+  const taskDepth = renderOrder[start]!.depth;
+  let end = start + 1;
   while (end < renderOrder.length && renderOrder[end]!.depth > taskDepth) {
     end++;
   }
 
-  const next = [...renderOrder];
-  next.splice(idx, end - idx);
-  return next;
+  return { start, end };
 };
 
 const subtreeTaskIds = (
-  renderOrder: ReadonlyArray<TaskStore["renderOrder"][number]>,
+  renderOrder: TaskStore["renderOrder"],
   taskId: TaskId,
 ): ReadonlyArray<TaskId> => {
-  const idx = renderOrder.findIndex((row) => row.id === taskId);
-  if (idx === -1) {
-    return [];
-  }
-
-  const taskDepth = renderOrder[idx]!.depth;
-  let end = idx + 1;
-  while (end < renderOrder.length && renderOrder[end]!.depth > taskDepth) {
-    end++;
-  }
-
-  return renderOrder.slice(idx, end).map((row) => row.id);
+  const range = findSubtreeRange(renderOrder, taskId);
+  return range === undefined ? [] : renderOrder.slice(range.start, range.end).map((row) => row.id);
 };
 
 interface StateUpdate {
@@ -204,7 +190,11 @@ const removeTransientSubtree = (
   nextTasks: Map<TaskId, TaskSnapshot>,
   taskId: TaskId,
 ) => {
-  const removedTaskIds = subtreeTaskIds(current.renderOrder, taskId);
+  const range = findSubtreeRange(current.renderOrder, taskId);
+  const removedTaskIds =
+    range === undefined
+      ? []
+      : current.renderOrder.slice(range.start, range.end).map((row) => row.id);
   for (const removedTaskId of removedTaskIds) {
     nextTasks.delete(removedTaskId);
   }
@@ -216,7 +206,10 @@ const removeTransientSubtree = (
 
   return {
     removedTaskIds,
-    renderOrder: removeFromRenderOrder(current.renderOrder, taskId),
+    renderOrder:
+      range === undefined
+        ? current.renderOrder
+        : current.renderOrder.toSpliced(range.start, range.end - range.start),
     columns: nextColumns,
   };
 };

--- a/tests/ink-renderer-store.test.ts
+++ b/tests/ink-renderer-store.test.ts
@@ -244,6 +244,43 @@ describe("progress render store", () => {
     );
   });
 
+  test.each(["completeTask", "failTask"] as const)(
+    "%s removes a nested transient subtree without removing its neighbors",
+    async (finalize) => {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const store = yield* makeProgressStore;
+          const columns: ReadonlyArray<ColumnDef<unknown>> = [{ render: () => "custom" }];
+          const rootId = yield* store.addTask({ description: "root", columns });
+          const leftId = yield* store.addTask({ description: "left", parentId: rootId, columns });
+          const branchId = yield* store.addTask({
+            description: "branch",
+            parentId: rootId,
+            transient: true,
+            columns,
+          });
+          yield* store.addTask({ description: "leaf", parentId: branchId, columns });
+          const rightId = yield* store.addTask({ description: "right", parentId: rootId, columns });
+          const rootSiblingId = yield* store.addTask({ description: "root sibling", columns });
+
+          yield* store[finalize](branchId);
+          store.flush();
+
+          const { snapshot } = store.getSnapshot();
+          const survivingIds = [rootId, leftId, rightId, rootSiblingId];
+          expect([...snapshot.tasks.keys()]).toEqual(survivingIds);
+          expect([...snapshot.columns.keys()]).toEqual(survivingIds);
+          expect(snapshot.renderOrder).toEqual([
+            { id: rootId, depth: 0 },
+            { id: leftId, depth: 1 },
+            { id: rightId, depth: 1 },
+            { id: rootSiblingId, depth: 0 },
+          ]);
+        }).pipe(Effect.scoped),
+      );
+    },
+  );
+
   test("does not publish terminal lifecycle events twice", async () => {
     await Effect.runPromise(
       Effect.gen(function* () {


### PR DESCRIPTION
`removeFromRenderOrder` and `subtreeTaskIds` each searched the depth-first render order for a task, then scanned forward until the first row outside its descendants. Transient task removal called both, repeating the same boundary search to determine removed IDs and then remove their rows.

This PR introduces `findSubtreeRange`, which returns a half-open `{ start, end }` range or `undefined` when the task is absent. `subtreeTaskIds` uses that helper for transient propagation. Transient removal computes the range once and uses it for both the removed IDs and a non-mutating `toSpliced` operation on render order.

For example, consider this order:

```text
index  depth  task
0      0      root
1      1        left
2      1        branch (transient)
3      2          leaf
4      1        right
5      0      root sibling
```

The branch range is `{ start: 2, end: 4 }`: it includes `branch` and `leaf`, and stops before `right`, whose depth is no longer greater than the branch's depth. Completing or failing the branch removes exactly those two IDs from tasks, columns, and render order. The surviving order remains `root`, `left`, `right`, `root sibling` with its original depths.

The old implementation produces the same result but locates the range twice. The new implementation has one boundary algorithm and reuses its result during removal. An absent task still yields no IDs and leaves the original render-order reference intact. Existing lifecycle and removal-event creation remain unchanged.

Validation: added two focused cases exercising completion and failure of a nested transient subtree surrounded by siblings. They verify surviving task IDs, column IDs, and render-order depths. Existing full-root subtree removal, event payload, depth-first ordering, and transient-propagation coverage also pass. Formatting and `bun run check` pass; the complete suite reports **119 tests, 0 failures**.
