### PR TITLE
refactor: share positional column size resolution

### DIFF
--- a/src/services/renderer/column-resolver.ts
+++ b/src/services/renderer/column-resolver.ts
@@ -90,38 +90,23 @@ export const resolveColumns = (
           },
     );
 
+    const resolveSize = (key: "flexGrow" | "flexShrink" | "flexBasis" | "minWidth") =>
+      maxDefined(
+        entries.map((entry) =>
+          entry === undefined
+            ? undefined
+            : resolveColumnSizeValue(entry.column[key], entry.prepared),
+        ),
+      );
+
     return {
       index,
       rows,
       entries,
-      flexGrow: maxDefined(
-        entries.map((entry) =>
-          entry === undefined
-            ? undefined
-            : resolveColumnSizeValue(entry.column.flexGrow, entry.prepared),
-        ),
-      ),
-      flexShrink: maxDefined(
-        entries.map((entry) =>
-          entry === undefined
-            ? undefined
-            : resolveColumnSizeValue(entry.column.flexShrink, entry.prepared),
-        ),
-      ),
-      flexBasis: maxDefined(
-        entries.map((entry) =>
-          entry === undefined
-            ? undefined
-            : resolveColumnSizeValue(entry.column.flexBasis, entry.prepared),
-        ),
-      ),
-      minWidth: maxDefined(
-        entries.map((entry) =>
-          entry === undefined
-            ? undefined
-            : resolveColumnSizeValue(entry.column.minWidth, entry.prepared),
-        ),
-      ),
+      flexGrow: resolveSize("flexGrow"),
+      flexShrink: resolveSize("flexShrink"),
+      flexBasis: resolveSize("flexBasis"),
+      minWidth: resolveSize("minWidth"),
     };
   });
 };


### PR DESCRIPTION
`resolveColumns` repeated the same aggregation four times for `flexGrow`, `flexShrink`, `flexBasis`, and `minWidth`. Each copy iterated the resolved entries, skipped missing columns, resolved either a numeric hint or a function using that entry's prepared data, and selected the maximum defined result. Changes to that policy required editing four nearly identical blocks.

This PR introduces a local `resolveSize` helper restricted to those four property names, then makes the returned layout fields explicit:

```ts
flexGrow: resolveSize("flexGrow"),
flexShrink: resolveSize("flexShrink"),
flexBasis: resolveSize("flexBasis"),
minWidth: resolveSize("minWidth"),
```

The helper uses the same `resolveColumnSizeValue` and `maxDefined` functions as before. The key is a literal union, so unrelated column properties such as `render` or `align` cannot be passed accidentally.

For example, if a visual column position contains three rows whose `minWidth` hints resolve to `4`, `undefined`, and `10`, the aggregate remains `10`. If every hint is missing, the result remains `undefined`; an explicit zero still counts as a defined value.

Function-based hints continue to receive the prepared value belonging to their own column entry. For instance, a definition with `prepare: rows => rows.length` and `flexBasis: count => count + 2` still resolves from its matching preparation group rather than another row's prepared data. The helper only centralizes how that result is aggregated.

This is a duplication cleanup: all four size properties are still resolved separately and in the same order. It introduces no cache, new traversal policy, or public API change.

Validation: `bun run format` and `bun run check` pass. All **117 existing tests pass**, including numeric size aggregation, isolation of prepared values by preparation function, different columns sharing a visual position, missing positional cells, and full-width/fixed-width bars. No new tests were needed for extracting the identical aggregation blocks.
