### PR TITLE
Remove unused renderer implementations

### DIFF
--- a/src/services/renderer/columns/description-column.tsx
+++ b/src/services/renderer/columns/description-column.tsx
@@ -1,9 +1,6 @@
 import cliSpinners, { type SpinnerName } from "cli-spinners";
-import { Box, Text, useBoxMetrics, type DOMElement } from "ink";
-import { useRef } from "react";
+import { Text } from "ink";
 import type { CellInfo, TaskSnapshot } from "../../../types";
-import { useSpinnerTick } from "../context/spinner-context";
-import type { TaskRowModel } from "../../store/types";
 import { isDeterminate } from "../shared/determinate";
 
 const MIN_TREE_DESCRIPTION_TEXT_WIDTH = 6;
@@ -120,28 +117,5 @@ export const DescriptionCell = ({
       <TaskIndicatorGlyph task={cell.task} tick={spinnerTick} />
       {` ${cell.task.description}`}
     </Text>
-  );
-};
-
-export const DescriptionColumn = ({ rows }: { readonly rows: ReadonlyArray<TaskRowModel> }) => {
-  const ref = useRef<DOMElement>(null!);
-  const { width, hasMeasured } = useBoxMetrics(ref);
-  const spinnerTick = useSpinnerTick();
-
-  const { minTreeWidth, preferredWidth } = prepareDescription(rows);
-
-  return (
-    <Box ref={ref} flexDirection="column" flexShrink={1} flexBasis={preferredWidth} minWidth={1}>
-      {rows.map((row) => (
-        <Box key={row.task.id} height={1}>
-          <DescriptionCell
-            cell={row}
-            width={hasMeasured ? width : undefined}
-            minTreeWidth={minTreeWidth}
-            spinnerTick={spinnerTick}
-          />
-        </Box>
-      ))}
-    </Box>
   );
 };

--- a/src/services/renderer/shared/format.ts
+++ b/src/services/renderer/shared/format.ts
@@ -106,8 +106,6 @@ interface DeterminateAmountParts {
   readonly total: string;
 }
 
-type DeterminateProcessedColor = "green" | "yellow" | "red" | "whiteBright";
-
 const formatDeterminateAmountParts = (task: TaskSnapshot): DeterminateAmountParts | undefined => {
   if (!isDeterminate(task)) {
     return undefined;
@@ -124,30 +122,6 @@ const formatDeterminateAmountParts = (task: TaskSnapshot): DeterminateAmountPart
     processed: processedText,
     total: totalText,
   };
-};
-
-export const getDeterminateProcessedColor = (task: TaskSnapshot): DeterminateProcessedColor => {
-  if (!isDeterminate(task)) {
-    return "whiteBright";
-  }
-
-  const { succeeded, failed, processed, total } = task.units;
-  if (task.status === "failed" && processed < total) {
-    return "red";
-  }
-  if (processed >= total && failed === 0) {
-    return "green";
-  }
-  if (processed >= total && failed > 0 && succeeded === 0) {
-    return "red";
-  }
-  if (succeeded > 0 && failed > 0) {
-    return "yellow";
-  }
-  if (failed > 0 && succeeded === 0) {
-    return "red";
-  }
-  return "whiteBright";
 };
 
 export const formatAmount = (task: TaskSnapshot): string => {

--- a/tests/ink-format.test.ts
+++ b/tests/ink-format.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import * as Progress from "../src";
 import { getTaskIndicator } from "../src/services/renderer/columns/description-column";
-import { formatAmount, getDeterminateProcessedColor } from "../src/services/renderer/shared/format";
+import { formatAmount } from "../src/services/renderer/shared/format";
 
 const makeTask = (
   units: Progress.TaskSnapshot["units"],
@@ -23,92 +23,6 @@ const makeTask = (
     ],
     metadata: undefined,
   });
-
-describe("determinate processed amount color", () => {
-  test("green for all succeeded", () => {
-    const task = makeTask(
-      {
-        succeeded: 4,
-        failed: 0,
-        processed: 4,
-        total: 4,
-      },
-      "done",
-    );
-
-    expect(getDeterminateProcessedColor(task)).toBe("green");
-  });
-
-  test("yellow for mixed successes and failures", () => {
-    const task = makeTask(
-      {
-        succeeded: 3,
-        failed: 1,
-        processed: 4,
-        total: 4,
-      },
-      "done",
-    );
-
-    expect(getDeterminateProcessedColor(task)).toBe("yellow");
-  });
-
-  test("red for fail-fast failures", () => {
-    const task = makeTask(
-      {
-        succeeded: 3,
-        failed: 1,
-        processed: 4,
-        total: 10,
-      },
-      "failed",
-    );
-
-    expect(getDeterminateProcessedColor(task)).toBe("red");
-  });
-
-  test("red when all result-mode effects failed", () => {
-    const task = makeTask(
-      {
-        succeeded: 0,
-        failed: 4,
-        processed: 4,
-        total: 4,
-      },
-      "done",
-    );
-
-    expect(getDeterminateProcessedColor(task)).toBe("red");
-  });
-
-  test("green for successful determinate overflow", () => {
-    const task = makeTask(
-      {
-        succeeded: 6,
-        failed: 0,
-        processed: 6,
-        total: 5,
-      },
-      "done",
-    );
-
-    expect(getDeterminateProcessedColor(task)).toBe("green");
-  });
-
-  test("green for zero-total determinate tasks", () => {
-    const task = makeTask(
-      {
-        succeeded: 0,
-        failed: 0,
-        processed: 0,
-        total: 0,
-      },
-      "done",
-    );
-
-    expect(getDeterminateProcessedColor(task)).toBe("green");
-  });
-});
 
 describe("determinate amount formatting", () => {
   test("renders only processed/total for processed-only mode", () => {

--- a/tests/renderer-description-column.test.tsx
+++ b/tests/renderer-description-column.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { renderToString } from "ink";
 import stripAnsi from "strip-ansi";
 import * as Progress from "../src";
-import { DescriptionColumn } from "../src/services/renderer/columns/description-column";
+import { ProgressRenderer } from "../src/services/renderer/public-api";
 import { NowProvider } from "../src/services/renderer/context/now-context";
 import { SpinnerProvider } from "../src/services/renderer/context/spinner-context";
 import type { TaskRowModel } from "../src/services/store/types";
@@ -67,7 +67,10 @@ const renderDescriptionColumn = (rows: ReadonlyArray<TaskRowModel>, spinnerTick?
     renderToString(
       <NowProvider active={false} nowOverride={0}>
         <SpinnerProvider active={false} tickOverride={spinnerTick}>
-          <DescriptionColumn rows={rows} />
+          <ProgressRenderer
+            rows={rows}
+            columns={new Map(rows.map((row) => [row.task.id, [Progress.Columns.description()]]))}
+          />
         </SpinnerProvider>
       </NowProvider>,
     ),
@@ -82,7 +85,7 @@ describe("renderer description tree planning", () => {
         hasNextSibling: false,
         ancestorHasNextSibling: [],
       }),
-      deriveRow(makeTask(2, "child", "running"), {
+      deriveRow(makeTask(2, "child task", "running"), {
         depth: 1,
         hasChildren: false,
         hasNextSibling: false,


### PR DESCRIPTION
## Problem

`DescriptionColumn` duplicates the column layout implemented by `ProgressRenderer`, but only tests render it. Those tests therefore bypass the layout used by applications. `getDeterminateProcessedColor` is also used only by tests; current amount cells color success/failure counts directly.

## Solution

Remove both unused implementations and the obsolete processed-color tests. Run the existing description assertions through `ProgressRenderer` with `Columns.description()` so spinner context, tree prefixes, and layout use the application path. Keep the shared description cell and indicator logic.

## Examples

- A nested running task still renders `└─ ⠋ child task`, and a spinner tick override of `2` still renders `⠹ root`.
- Description tests now pass a per-task column map to `ProgressRenderer` instead of mounting a separate `DescriptionColumn`.
- The tree-prefix fixture has enough text width to display its prefix under the real renderer's existing narrow-column policy.

No package exports change.

## Validation

- `bun test`: 119 passed; six tests of the removed color helper were deleted.
- `bun run typecheck`
- `bun run lint`
- `bun run format` and `bun run format:check`
