### PR TITLE
Publish task snapshots without unused lifecycle events

### DIFF
--- a/examples/benchmarks.ts
+++ b/examples/benchmarks.ts
@@ -54,7 +54,7 @@ const benchmarkStore = (taskCount: number) =>
 
       // Publication and correctness checks are outside the timed section.
       store.flush();
-      const tasks = store.getSnapshot().snapshot.tasks;
+      const tasks = store.getSnapshot().tasks;
       assert.equal(tasks.size, taskCount);
       for (const [id, task] of tasks) {
         assert.equal(task.units.succeeded, id === hotTaskId ? (round + 1) * STORE_UPDATES : 0);

--- a/src/services/renderer/hooks/use-progress-render-view.ts
+++ b/src/services/renderer/hooks/use-progress-render-view.ts
@@ -1,14 +1,15 @@
 import { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
-import type { ProgressStoreShape, RenderPublication } from "../../store/store";
+import type { ProgressStoreShape } from "../../store/store";
+import type { TaskStore } from "../../../types";
 import { toRenderSnapshot, type RenderSnapshot } from "../../store/render-snapshot";
 
 interface ProgressRenderView {
-  readonly publication: RenderPublication;
+  readonly storeSnapshot: TaskStore;
   readonly renderSnapshot: RenderSnapshot;
   readonly hasRunningTasks: boolean;
 }
 
-const useRenderSnapshot = (storeSnapshot: RenderPublication["snapshot"]): RenderSnapshot => {
+const useRenderSnapshot = (storeSnapshot: TaskStore): RenderSnapshot => {
   const previousSnapshotRef = useRef<RenderSnapshot | undefined>(undefined);
 
   const renderSnapshot = useMemo(
@@ -24,11 +25,11 @@ const useRenderSnapshot = (storeSnapshot: RenderPublication["snapshot"]): Render
 };
 
 export const useProgressRenderView = (store: ProgressStoreShape): ProgressRenderView => {
-  const publication = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
-  const renderSnapshot = useRenderSnapshot(publication.snapshot);
+  const storeSnapshot = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
+  const renderSnapshot = useRenderSnapshot(storeSnapshot);
 
   return {
-    publication,
+    storeSnapshot,
     renderSnapshot,
     hasRunningTasks: renderSnapshot.hasRunningTasks,
   };

--- a/src/services/renderer/renderer.tsx
+++ b/src/services/renderer/renderer.tsx
@@ -14,12 +14,12 @@ interface RendererShape {
 const MAX_FPS = 24;
 
 const ProgressRoot = ({ store }: { readonly store: ProgressStoreShape }) => {
-  const { renderSnapshot, hasRunningTasks, publication } = useProgressRenderView(store);
+  const { renderSnapshot, hasRunningTasks, storeSnapshot } = useProgressRenderView(store);
 
   return (
     <SpinnerProvider active={hasRunningTasks}>
       <NowProvider active={hasRunningTasks}>
-        <ProgressRenderer rows={renderSnapshot.rows} columns={publication.snapshot.columns} />
+        <ProgressRenderer rows={renderSnapshot.rows} columns={storeSnapshot.columns} />
       </NowProvider>
     </SpinnerProvider>
   );

--- a/src/services/store/store.ts
+++ b/src/services/store/store.ts
@@ -2,21 +2,12 @@ import { Clock, Context, Effect, Layer, Option, Queue } from "effect";
 import type {
   AddTaskOptions,
   ColumnDef,
-  ProgressTaskEvent,
   TaskProgressSample,
   TaskId,
   TaskStore,
   UpdateTaskOptions,
 } from "../../types";
 import { TaskId as makeTaskId, TaskSnapshot } from "../../types";
-import {
-  TaskAddedEvent,
-  TaskAdvancedEvent,
-  TaskCompletedEvent,
-  TaskFailedEvent,
-  TaskRemovedEvent,
-  TaskUpdatedEvent,
-} from "../../types";
 
 interface TaskCounts {
   readonly succeeded: number;
@@ -27,13 +18,8 @@ interface TaskCounts {
 const ETA_SAMPLE_WINDOW_MILLIS = 30_000;
 const ETA_SAMPLE_MAX_LENGTH = 1_000;
 
-export interface RenderPublication {
-  readonly snapshot: TaskStore;
-  readonly events: ReadonlyArray<ProgressTaskEvent>;
-}
-
 export interface ProgressStoreShape {
-  readonly getSnapshot: () => RenderPublication;
+  readonly getSnapshot: () => TaskStore;
   readonly subscribe: (listener: () => void) => () => void;
   readonly flush: () => void;
   readonly addTask: (options: AddTaskOptions<any>) => Effect.Effect<TaskId>;
@@ -194,11 +180,6 @@ const subtreeTaskIds = (
   return range === undefined ? [] : renderOrder.slice(range.start, range.end).map((row) => row.id);
 };
 
-interface StateUpdate {
-  readonly state: TaskStore;
-  readonly events: ReadonlyArray<ProgressTaskEvent>;
-}
-
 const removeTransientSubtree = (
   current: TaskStore,
   nextTasks: Map<TaskId, TaskSnapshot>,
@@ -219,7 +200,6 @@ const removeTransientSubtree = (
   }
 
   return {
-    removedTaskIds,
     renderOrder:
       range === undefined
         ? current.renderOrder
@@ -242,11 +222,7 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
     renderOrder: [],
     columns: new Map<TaskId, ReadonlyArray<ColumnDef<any, any>>>(),
   };
-  let pendingEvents: Array<ProgressTaskEvent> = [];
-  let publishedPublication: RenderPublication = {
-    snapshot: state,
-    events: [],
-  };
+  let publishedSnapshot = state;
   let hasPendingPublish = false;
   let lastPublishAt = -SNAPSHOT_PUBLISH_INTERVAL_MILLIS;
   let latestObservedAt = 0;
@@ -259,15 +235,9 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
   };
 
   const publishNow = (publishedAt: number): void => {
-    const nextPublication: RenderPublication = {
-      snapshot: state,
-      events: [...pendingEvents],
-    };
-
     hasPendingPublish = false;
-    publishedPublication = nextPublication;
+    publishedSnapshot = state;
     notifyListeners();
-    pendingEvents = [];
     lastPublishAt = publishedAt;
   };
 
@@ -304,25 +274,19 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
     yield* Queue.offer(publishQueue, undefined);
   });
 
-  const publish = (update: StateUpdate, now: number): Effect.Effect<void> => {
-    if (update.state === state) {
+  const updateState = (
+    transform: (current: TaskStore) => TaskStore,
+    now: number,
+  ): Effect.Effect<void> => {
+    const nextState = transform(state);
+    if (nextState === state) {
       return Effect.void;
     }
 
     latestObservedAt = now;
-    state = update.state;
-    if (update.events.length > 0) {
-      pendingEvents.push(...update.events);
-    }
+    state = nextState;
     hasPendingPublish = true;
     return schedulePublish;
-  };
-
-  const updateState = (
-    transform: (current: TaskStore) => StateUpdate,
-    now: number,
-  ): Effect.Effect<void> => {
-    return publish(transform(state), now);
   };
 
   const incrementCounter = (taskId: TaskId, kind: "succeeded" | "failed", amount: number) =>
@@ -332,7 +296,7 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
       yield* updateState((current) => {
         const currentTask = current.tasks.get(taskId);
         if (!currentTask) {
-          return { state: current, events: [] };
+          return current;
         }
 
         const units = normalizeUnits({
@@ -355,10 +319,7 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
           }),
         );
 
-        return {
-          state: { tasks: nextTasks, renderOrder: current.renderOrder, columns: current.columns },
-          events: [new TaskAdvancedEvent({ taskId, amount, kind })],
-        };
+        return { tasks: nextTasks, renderOrder: current.renderOrder, columns: current.columns };
       }, now);
     });
 
@@ -369,27 +330,17 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
       yield* updateState((current) => {
         const currentTask = current.tasks.get(taskId);
         if (!currentTask || currentTask.status !== "running") {
-          return { state: current, events: [] };
+          return current;
         }
 
-        const event =
-          status === "done" ? new TaskCompletedEvent({ taskId }) : new TaskFailedEvent({ taskId });
         const nextTasks = new Map(current.tasks);
         if (currentTask.transient) {
           const removedSubtree = removeTransientSubtree(current, nextTasks, taskId);
 
           return {
-            state: {
-              tasks: nextTasks,
-              renderOrder: removedSubtree.renderOrder,
-              columns: removedSubtree.columns,
-            },
-            events: [
-              event,
-              ...removedSubtree.removedTaskIds.map(
-                (removedTaskId) => new TaskRemovedEvent({ taskId: removedTaskId }),
-              ),
-            ],
+            tasks: nextTasks,
+            renderOrder: removedSubtree.renderOrder,
+            columns: removedSubtree.columns,
           };
         }
 
@@ -408,15 +359,12 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
           }),
         );
 
-        return {
-          state: { tasks: nextTasks, renderOrder: current.renderOrder, columns: current.columns },
-          events: [event],
-        };
+        return { tasks: nextTasks, renderOrder: current.renderOrder, columns: current.columns };
       }, now);
     });
 
   const store: ProgressStoreShape = {
-    getSnapshot: () => publishedPublication,
+    getSnapshot: () => publishedSnapshot,
     subscribe: (listener) => {
       listeners.add(listener);
       return () => {
@@ -470,19 +418,7 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
               )
             : current.columns;
 
-          return {
-            state: { tasks: nextTasks, renderOrder: nextRenderOrder, columns: nextColumns },
-            events: [
-              new TaskAddedEvent({
-                taskId,
-                parentId,
-                description: task.description,
-                total: task.units.total,
-                transient: task.transient,
-                countDisplay: task.countDisplay,
-              }),
-            ],
-          };
+          return { tasks: nextTasks, renderOrder: nextRenderOrder, columns: nextColumns };
         }, now);
 
         return taskId;
@@ -494,28 +430,12 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
         yield* updateState((current) => {
           const currentTask = current.tasks.get(taskId);
           if (!currentTask) {
-            return { state: current, events: [] };
+            return current;
           }
 
           const nextTask = updatedSnapshot(currentTask, options, now);
           const nextTasks = new Map(current.tasks);
           nextTasks.set(taskId, nextTask);
-
-          const events: Array<ProgressTaskEvent> = [
-            new TaskUpdatedEvent({
-              taskId,
-              description: options.description ?? undefined,
-              succeeded: options.succeeded ?? undefined,
-              failed: options.failed ?? undefined,
-              processed:
-                options.succeeded !== undefined || options.failed !== undefined
-                  ? nextTask.units.processed
-                  : undefined,
-              total: hasExplicitTotal(options) ? nextTask.units.total : undefined,
-              transient: options.transient ?? undefined,
-              countDisplay: options.countDisplay ?? undefined,
-            }),
-          ];
 
           if (options.transient !== undefined) {
             for (const candidateId of subtreeTaskIds(current.renderOrder, taskId).slice(1)) {
@@ -526,19 +446,10 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
 
               const nextCandidate = TaskSnapshot({ ...candidate, transient: nextTask.transient });
               nextTasks.set(candidateId, nextCandidate);
-              events.push(
-                new TaskUpdatedEvent({
-                  taskId: candidateId,
-                  transient: nextCandidate.transient,
-                }),
-              );
             }
           }
 
-          return {
-            state: { tasks: nextTasks, renderOrder: current.renderOrder, columns: current.columns },
-            events,
-          };
+          return { tasks: nextTasks, renderOrder: current.renderOrder, columns: current.columns };
         }, now);
       }),
     incrementSucceeded: (taskId, amount = 1) => incrementCounter(taskId, "succeeded", amount),
@@ -554,16 +465,13 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
         yield* updateState((current) => {
           const currentTask = current.tasks.get(taskId);
           if (!currentTask) {
-            return { state: current, events: [] };
+            return current;
           }
 
           const nextTasks = new Map(current.tasks);
           nextTasks.set(taskId, TaskSnapshot({ ...currentTask, metadata }));
 
-          return {
-            state: { tasks: nextTasks, renderOrder: current.renderOrder, columns: current.columns },
-            events: [],
-          };
+          return { tasks: nextTasks, renderOrder: current.renderOrder, columns: current.columns };
         }, now);
       }),
     getMetadata: (taskId) =>

--- a/tests/ink-renderer-store.test.ts
+++ b/tests/ink-renderer-store.test.ts
@@ -81,6 +81,8 @@ describe("progress render store", () => {
         });
 
         expect(notifications).toBe(1);
+        const initialSnapshot = store.getSnapshot();
+        expect(store.getSnapshot()).toBe(initialSnapshot);
 
         yield* store.incrementSucceeded(taskId, 1);
         yield* store.incrementSucceeded(taskId, 1);
@@ -90,18 +92,20 @@ describe("progress render store", () => {
 
         yield* TestClock.adjust(99);
         expect(notifications).toBe(1);
+        expect(store.getSnapshot()).toBe(initialSnapshot);
+        expect(initialSnapshot.tasks.get(taskId)?.units.processed).toBe(0);
 
         yield* TestClock.adjust(1);
         expect(notifications).toBe(2);
 
         const publication = store.getSnapshot();
-        const task = publication.snapshot.tasks.get(taskId);
-        expect(publication.snapshot.renderOrder).toHaveLength(1);
+        expect(publication).not.toBe(initialSnapshot);
+        const task = publication.tasks.get(taskId);
+        expect(publication.renderOrder).toHaveLength(1);
         expect(task?.units.total).toBe(10);
         expect(task?.units.succeeded).toBe(2);
         expect(task?.units.failed).toBe(1);
         expect(task?.units.processed).toBe(3);
-        expect(publication.events).toHaveLength(3);
       }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
     );
   });
@@ -131,87 +135,13 @@ describe("progress render store", () => {
         store.flush();
 
         expect(notifications).toBe(2);
-        const task = store.getSnapshot().snapshot.tasks.get(taskId);
+        const task = store.getSnapshot().tasks.get(taskId);
         expect(task?.units.total).toBe(4);
         expect(task?.units.processed).toBe(2);
 
         yield* TestClock.adjust(100);
         expect(notifications).toBe(2);
       }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
-    );
-  });
-
-  test("publishes concrete lifecycle event payloads", async () => {
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const store = yield* makeProgressStore;
-
-        const taskId = yield* store.addTask({
-          description: "event-task",
-          total: 5,
-          transient: false,
-          countDisplay: "processedOnly",
-        });
-
-        const added = store.getSnapshot().events;
-        expect(added).toHaveLength(1);
-        expect(added[0]).toMatchObject({
-          _tag: "TaskAdded",
-          taskId,
-          parentId: null,
-          description: "event-task",
-          total: 5,
-          transient: false,
-          countDisplay: "processedOnly",
-        });
-
-        yield* store.updateTask(taskId, {
-          description: "event-task-updated",
-          succeeded: 1,
-          failed: 1,
-          total: 6,
-          transient: true,
-          countDisplay: "detailed",
-        });
-        yield* store.incrementSucceeded(taskId, 2);
-        yield* store.incrementFailed(taskId, 1);
-        yield* store.completeTask(taskId);
-        store.flush();
-
-        expect(store.getSnapshot().events).toEqual([
-          expect.objectContaining({
-            _tag: "TaskUpdated",
-            taskId,
-            description: "event-task-updated",
-            succeeded: 1,
-            failed: 1,
-            processed: 2,
-            total: 6,
-            transient: true,
-            countDisplay: "detailed",
-          }),
-          expect.objectContaining({
-            _tag: "TaskAdvanced",
-            taskId,
-            amount: 2,
-            kind: "succeeded",
-          }),
-          expect.objectContaining({
-            _tag: "TaskAdvanced",
-            taskId,
-            amount: 1,
-            kind: "failed",
-          }),
-          expect.objectContaining({
-            _tag: "TaskCompleted",
-            taskId,
-          }),
-          expect.objectContaining({
-            _tag: "TaskRemoved",
-            taskId,
-          }),
-        ]);
-      }).pipe(Effect.scoped),
     );
   });
 
@@ -228,7 +158,7 @@ describe("progress render store", () => {
 
         store.flush();
 
-        expect(store.getSnapshot().snapshot.renderOrder).toEqual([
+        expect(store.getSnapshot().renderOrder).toEqual([
           { id: parentId, depth: 0 },
           { id: childId, depth: 1 },
           { id: grandchildId, depth: 2 },
@@ -255,7 +185,7 @@ describe("progress render store", () => {
           parentId,
           columns,
         });
-        const grandchildId = yield* store.addTask({
+        yield* store.addTask({
           description: "grandchild",
           parentId: childId,
           columns,
@@ -266,15 +196,9 @@ describe("progress render store", () => {
         store.flush();
 
         const publication = store.getSnapshot();
-        expect(publication.snapshot.tasks.size).toBe(0);
-        expect(publication.snapshot.renderOrder).toEqual([]);
-        expect(publication.snapshot.columns.size).toBe(0);
-        expect(publication.events).toEqual([
-          expect.objectContaining({ _tag: "TaskCompleted", taskId: parentId }),
-          expect.objectContaining({ _tag: "TaskRemoved", taskId: parentId }),
-          expect.objectContaining({ _tag: "TaskRemoved", taskId: childId }),
-          expect.objectContaining({ _tag: "TaskRemoved", taskId: grandchildId }),
-        ]);
+        expect(publication.tasks.size).toBe(0);
+        expect(publication.renderOrder).toEqual([]);
+        expect(publication.columns.size).toBe(0);
       }).pipe(Effect.scoped),
     );
   });
@@ -301,7 +225,7 @@ describe("progress render store", () => {
           yield* store[finalize](branchId);
           store.flush();
 
-          const { snapshot } = store.getSnapshot();
+          const snapshot = store.getSnapshot();
           const survivingIds = [rootId, leftId, rightId, rootSiblingId];
           expect([...snapshot.tasks.keys()]).toEqual(survivingIds);
           expect([...snapshot.columns.keys()]).toEqual(survivingIds);
@@ -316,7 +240,7 @@ describe("progress render store", () => {
     },
   );
 
-  test("does not publish terminal lifecycle events twice", async () => {
+  test("does not republish already-finalized tasks", async () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const store = yield* makeProgressStore;
@@ -329,18 +253,14 @@ describe("progress render store", () => {
         yield* store.completeTask(completedId);
         store.flush();
 
-        expect(store.getSnapshot().events).toEqual([
-          expect.objectContaining({ _tag: "TaskCompleted", taskId: completedId }),
-        ]);
+        expect(store.getSnapshot().tasks.get(completedId)?.status).toBe("done");
         const afterCompleteNotifications = notifications;
 
         yield* store.failTask(completedId);
         store.flush();
 
         expect(notifications).toBe(afterCompleteNotifications);
-        expect(store.getSnapshot().events).toEqual([
-          expect.objectContaining({ _tag: "TaskCompleted", taskId: completedId }),
-        ]);
+        expect(store.getSnapshot().tasks.get(completedId)?.status).toBe("done");
 
         const failedId = yield* store.addTask({ description: "failed", transient: false });
         store.flush();
@@ -348,18 +268,14 @@ describe("progress render store", () => {
         yield* store.failTask(failedId);
         store.flush();
 
-        expect(store.getSnapshot().events).toEqual([
-          expect.objectContaining({ _tag: "TaskFailed", taskId: failedId }),
-        ]);
+        expect(store.getSnapshot().tasks.get(failedId)?.status).toBe("failed");
         const afterFailNotifications = notifications;
 
         yield* store.completeTask(failedId);
         store.flush();
 
         expect(notifications).toBe(afterFailNotifications);
-        expect(store.getSnapshot().events).toEqual([
-          expect.objectContaining({ _tag: "TaskFailed", taskId: failedId }),
-        ]);
+        expect(store.getSnapshot().tasks.get(failedId)?.status).toBe("failed");
       }).pipe(Effect.scoped),
     );
   });


### PR DESCRIPTION
Depends on #32; this PR targets `codex/unify-store-finalization` so its diff contains only event/publication cleanup.

## Problem

Every task mutation constructs lifecycle-event objects and appends them to a pending array. Publication copies that array alongside the task snapshot, although the renderer consumes only the snapshot. This adds event-building branches, wrapper types, and allocations to the update path without an application consumer.

## Solution

Publish `TaskStore` snapshots directly. Remove internal event construction, the pending-event array, `StateUpdate`, and `RenderPublication`; state transforms now return the next store directly. Update the renderer hook and benchmark to consume that shape. Keep the existing 100 ms publication cadence, explicit flush, and immutable snapshot behavior.

Public event classes, schemas, and `decodeProgressTaskEvent` remain exported for compatibility. This changes the internal store API, not the package's task API.

## Examples

- Three increments within one publication interval still yield one notification with the accumulated counts, without allocating three unused event payloads.
- Internal consumers now use `store.getSnapshot().tasks` instead of `store.getSnapshot().snapshot.tasks`.
- A previously published snapshot keeps its original counts while updates are pending; the next publication supplies a new snapshot reference.
- Completing a transient parent still removes its subtree from tasks, render order, and columns.

## Validation

- `bun test`: 124 passed. Removed the obsolete event-payload test; kept subtree and terminal-state assertions and strengthened the coalescing test to verify snapshot identity and immutability.
- `bun run typecheck` (including the benchmark consumer)
- `bun run lint`
- `bun run format` and `bun run format:check`
