### PR TITLE
Let task scopes own shared finalization

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -241,30 +241,14 @@ export const forEach: {
 
         return yield* progress.task(
           (handle) =>
-            Effect.gen(function* () {
-              const taskId = handle.id;
-              const exit = yield* Effect.exit(
-                Effect.forEach(
-                  iterable,
-                  (item, index) => wrapTrackedEffect(progress, taskId, f(item, index)),
-                  {
-                    concurrency: options.concurrency,
-                    discard: options.discard,
-                  },
-                ),
-              );
-
-              if (Exit.isSuccess(exit)) {
-                yield* progress.completeTask(taskId);
-              } else {
-                yield* progress.failTask(taskId);
-              }
-
-              return yield* Exit.match(exit, {
-                onFailure: Effect.failCause,
-                onSuccess: Effect.succeed,
-              });
-            }),
+            Effect.forEach(
+              iterable,
+              (item, index) => wrapTrackedEffect(progress, handle.id, f(item, index)),
+              {
+                concurrency: options.concurrency,
+                discard: options.discard,
+              },
+            ),
           {
             description: options.description,
             total: options.total ?? inferTotal(iterable),

--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -98,29 +98,15 @@ const makeProgressService = Effect.gen(function* () {
         | Effect.Effect<A, E, R>
         | ((handle: TaskHandle<any>) => Effect.Effect<A, E, R>),
       options: AddTaskOptions<any>,
-    ) => {
-      if (typeof effectOrCallback === "function") {
-        return scopedTask(
-          Effect.gen(function* () {
-            const taskId = yield* Task;
-            const handle = makeTaskHandle(taskId);
-            const exit = yield* Effect.exit(effectOrCallback(handle));
-
-            yield* autoFinalizeIfRunning(taskId, exit);
-
-            return yield* Exit.match(exit, {
-              onFailure: Effect.failCause,
-              onSuccess: Effect.succeed,
-            });
-          }),
-          options,
-        );
-      }
-
-      return scopedTask(
+    ) =>
+      scopedTask(
         Effect.gen(function* () {
           const taskId = yield* Task;
-          const exit = yield* Effect.exit(effectOrCallback);
+          const effect =
+            typeof effectOrCallback === "function"
+              ? effectOrCallback(makeTaskHandle(taskId))
+              : effectOrCallback;
+          const exit = yield* Effect.exit(effect);
 
           yield* autoFinalizeIfRunning(taskId, exit);
 
@@ -130,8 +116,7 @@ const makeProgressService = Effect.gen(function* () {
           });
         }),
         options,
-      );
-    },
+      ),
   );
 
   const service = {


### PR DESCRIPTION
## Problem

The effect and callback forms of `task` duplicate the same exit capture, auto-finalization, and value/failure propagation. `forEach` repeats this lifecycle handling inside a callback whose enclosing task already auto-finalizes, resulting in two layers of finalization logic.

## Solution

Resolve the effect or callback inside a single task scope and use one shared exit/finalization path. Let `forEach` return its tracked `Effect.forEach` directly; the enclosing task owns finalization. Keep per-item success/failure accounting and `all`'s separate result-mode/full-accounting policy unchanged.

## Examples

```ts
Progress.task(Effect.succeed("ok"), { description: "work" })
Progress.task(() => Effect.succeed("ok"), { description: "work" })
```

Both forms use the same lifecycle path and return `"ok"` with a completed task. A callback that explicitly yields `handle.fail` before returning `"ok"` still leaves the task failed.

For `forEach([1, 2, 3], ...)`, if item 1 succeeds and item 2 fails in sequential execution, the task still ends failed with succeeded `1`, failed `1`, and processed `2`; item 3 is not counted. Successful and empty traversals still complete automatically.

## Validation

All 125 tests passed, including nested service reuse, task context, explicit completion/failure overrides, empty traversals, fail-fast accounting, pipe forms, and `all` result mode. Typecheck, lint, formatting, and formatting check passed.
