### PR TITLE
Simplify render-row caching and preserve useful reuse

### DIFF
--- a/src/services/store/render-snapshot.ts
+++ b/src/services/store/render-snapshot.ts
@@ -55,52 +55,25 @@ const sameTreePrefixInputs = (left: TaskRowModel["tree"], right: TaskRowModel["t
   left.hasNextSibling === right.hasNextSibling &&
   arraysEqual(left.ancestorHasNextSibling, right.ancestorHasNextSibling);
 
-const sameTree = (left: TaskRowModel["tree"], right: TaskRowModel["tree"]): boolean =>
-  sameTreePrefixInputs(left, right) && left.hasChildren === right.hasChildren;
-
 const deriveRow = (
   task: OrderedTask["snapshot"],
-  tree: TaskRowModel["tree"],
+  treePrefix: string,
   previousRow: TaskRowModel | undefined,
 ): TaskRowModel["derived"] => {
-  if (previousRow !== undefined && previousRow.task === task && sameTree(previousRow.tree, tree)) {
-    return previousRow.derived;
-  }
-
-  const treePrefix =
-    previousRow !== undefined && sameTreePrefixInputs(previousRow.tree, tree)
-      ? previousRow.derived.treePrefix
-      : renderTreePrefix(tree);
-  const treePrefixWidth =
-    previousRow !== undefined && sameTreePrefixInputs(previousRow.tree, tree)
-      ? previousRow.derived.treePrefixWidth
-      : // Tree prefixes are built from fixed box-drawing glyphs we treat as single-cell.
-        treePrefix.length;
-
+  // Tree prefixes are built from fixed box-drawing glyphs we treat as single-cell.
+  const treePrefixWidth = treePrefix.length;
   const descriptionWidth =
     previousRow !== undefined && previousRow.task.description === task.description
       ? previousRow.derived.descriptionWidth
       : textWidth(task.description);
-
-  const isDeterminate =
-    previousRow !== undefined && previousRow.task.units.total === task.units.total
-      ? previousRow.derived.isDeterminate
-      : task.units.total !== undefined;
-
-  const hasRenderableProgress =
-    previousRow !== undefined &&
-    previousRow.task.units.total === task.units.total &&
-    previousRow.task.units.processed === task.units.processed
-      ? previousRow.derived.hasRenderableProgress
-      : task.units.total !== undefined || task.units.processed > 0;
 
   return {
     treePrefix,
     treePrefixWidth,
     descriptionWidth,
     treePrefixedDescriptionWidth: treePrefixWidth + descriptionWidth,
-    hasRenderableProgress,
-    isDeterminate,
+    hasRenderableProgress: task.units.total !== undefined || task.units.processed > 0,
+    isDeterminate: task.units.total !== undefined,
   };
 };
 
@@ -139,20 +112,20 @@ const computeTreeInfo = (
 
     ancestorStateByDepth[depth] = hasNextSiblingByIndex[index] ?? false;
 
-    if (
-      previousRow !== undefined &&
-      previousRow.task === entry.snapshot &&
-      sameTree(previousRow.tree, tree)
-    ) {
+    const prefixUnchanged =
+      previousRow !== undefined && sameTreePrefixInputs(previousRow.tree, tree);
+    const treeUnchanged = prefixUnchanged && previousRow.tree.hasChildren === tree.hasChildren;
+
+    if (treeUnchanged && previousRow.task === entry.snapshot) {
       return previousRow;
     }
 
-    const derived = deriveRow(entry.snapshot, tree, previousRow);
+    const treePrefix = prefixUnchanged ? previousRow.derived.treePrefix : renderTreePrefix(tree);
 
     return {
       task: entry.snapshot,
-      tree: previousRow !== undefined && sameTree(previousRow.tree, tree) ? previousRow.tree : tree,
-      derived,
+      tree: treeUnchanged ? previousRow.tree : tree,
+      derived: deriveRow(entry.snapshot, treePrefix, previousRow),
     };
   });
 };

--- a/tests/render-snapshot.test.ts
+++ b/tests/render-snapshot.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import { TaskId, type TaskSnapshot, type TaskStore } from "../src/types";
+import { toRenderSnapshot } from "../src/services/store/render-snapshot";
+
+const makeTask = (id: number, description: string): TaskSnapshot => ({
+  id: TaskId(id),
+  parentId: null,
+  description,
+  status: "running",
+  countDisplay: "detailed",
+  transient: false,
+  units: { succeeded: 0, failed: 0, processed: 0 },
+  startedAt: 0,
+  completedAt: null,
+  progressSamples: [{ timestamp: 0, processed: 0 }],
+  metadata: undefined,
+});
+
+const makeStore = (entries: ReadonlyArray<readonly [TaskSnapshot, number]>): TaskStore => ({
+  tasks: new Map(entries.map(([task]) => [task.id, task])),
+  renderOrder: entries.map(([task, depth]) => ({ id: task.id, depth })),
+  columns: new Map(),
+});
+
+describe("render snapshot reuse", () => {
+  test("reuses unchanged rows and tree data while updating progress flags and text widths", () => {
+    const root = makeTask(1, "root");
+    const child = { ...makeTask(2, "下载"), parentId: root.id };
+    const first = toRenderSnapshot(
+      makeStore([
+        [root, 0],
+        [child, 1],
+      ]),
+    );
+    const counted = { ...child, units: { succeeded: 1, failed: 0, processed: 1 } };
+    const second = toRenderSnapshot(
+      makeStore([
+        [root, 0],
+        [counted, 1],
+      ]),
+      first,
+    );
+
+    expect(second.rows[0]).toBe(first.rows[0]);
+    expect(second.rows[1]).not.toBe(first.rows[1]);
+    expect(second.rows[1]!.tree).toBe(first.rows[1]!.tree);
+    expect(first.rows[1]!.derived.hasRenderableProgress).toBeFalse();
+    expect(second.rows[1]!.derived).toMatchObject({
+      treePrefix: "└─ ",
+      descriptionWidth: 4,
+      treePrefixedDescriptionWidth: 7,
+      hasRenderableProgress: true,
+      isDeterminate: false,
+    });
+
+    const renamed = { ...counted, description: "download", units: { ...counted.units, total: 2 } };
+    const third = toRenderSnapshot(
+      makeStore([
+        [root, 0],
+        [renamed, 1],
+      ]),
+      second,
+    );
+    expect(third.rows[1]!.derived).toMatchObject({
+      descriptionWidth: 8,
+      treePrefixedDescriptionWidth: 11,
+      isDeterminate: true,
+    });
+  });
+
+  test("updates children and ancestor connectors when the task tree grows", () => {
+    const root = makeTask(1, "root");
+    const child = { ...makeTask(2, "child"), parentId: root.id };
+    const leaf = { ...makeTask(3, "leaf"), parentId: child.id };
+    const sibling = { ...makeTask(4, "sibling"), parentId: root.id };
+    const first = toRenderSnapshot(
+      makeStore([
+        [root, 0],
+        [child, 1],
+      ]),
+    );
+    const second = toRenderSnapshot(
+      makeStore([
+        [root, 0],
+        [child, 1],
+        [leaf, 2],
+      ]),
+      first,
+    );
+
+    expect(second.rows[1]!.tree.hasChildren).toBeTrue();
+    expect(second.rows[1]!.tree).not.toBe(first.rows[1]!.tree);
+    expect(second.rows[1]!.derived.treePrefix).toBe("└─ ");
+    expect(second.rows[2]!.derived.treePrefix).toBe("   └─ ");
+
+    const third = toRenderSnapshot(
+      makeStore([
+        [root, 0],
+        [child, 1],
+        [leaf, 2],
+        [sibling, 1],
+      ]),
+      second,
+    );
+    expect(third.rows[0]).toBe(second.rows[0]);
+    expect(third.rows[1]!.derived.treePrefix).toBe("├─ ");
+    expect(third.rows[2]!.derived.treePrefix).toBe("│  └─ ");
+    expect(third.rows[3]!.derived.treePrefix).toBe("└─ ");
+  });
+});


### PR DESCRIPTION
## Problem

Row derivation repeatedly compares the same tree inputs and checks previous counts to cache inexpensive boolean expressions. It also repeats an unchanged-row guard that the caller already handles. This makes the cache's invalidation rules harder to follow than the values being computed.

## Solution

Compare tree-prefix inputs once per row and derive full-tree equality from that result. Keep unchanged row/tree references, cached tree prefixes, and Unicode text-width reuse. Calculate `isDeterminate`, `hasRenderableProgress`, and the fixed-glyph prefix width directly. Remove the redundant derived-row guard.

## Examples

- Updating a child's count reuses the unchanged parent row and the child's tree object, while updating the child's progress flags.
- A description of `下载` still measures four terminal cells; renaming it to `download` recalculates the width as eight.
- Adding a sibling changes the child's prefix from `└─ ` to `├─ ` and its descendant's prefix from `   └─ ` to `│  └─ `.
- Adding the first child updates `hasChildren` even when the parent's prefix is unchanged.

## Validation

`bun test`: 127 passed, including two focused tests for cache reuse and tree/text invalidation. Typecheck, lint, formatting, and formatting check passed. This is a simplification of cache logic; no runtime speedup is claimed without a benchmark.
