### PR TITLE
Share task operations between the service and store

### DIFF
--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -32,7 +32,7 @@ const makeProgressService = Effect.gen(function* () {
   // Let the renderer fiber start so queued logs are reliably flushed on scope teardown.
   yield* Effect.sleep("0 millis");
 
-  const addTask = (options: AddTaskOptions) =>
+  const addTask = <M>(options: AddTaskOptions<M>) =>
     Effect.gen(function* () {
       const resolvedParentId =
         options.parentId === undefined ? yield* currentParentId : Option.some(options.parentId);
@@ -42,41 +42,33 @@ const makeProgressService = Effect.gen(function* () {
       });
     });
 
-  const updateTask = store.updateTask;
-  const incrementSucceeded = store.incrementSucceeded;
-  const incrementFailed = store.incrementFailed;
-  const completeTask = store.completeTask;
-  const failTask = store.failTask;
-  const getTask = store.getTask;
-  const listTasks = store.listTasks;
-  const setMetadata = store.setMetadata;
-  const getMetadata = store.getMetadata;
-
   const makeTaskHandle = <M>(taskId: TaskId): TaskHandle<M> => ({
     id: taskId,
-    getMetadata: getMetadata(taskId) as Effect.Effect<M>,
-    setMetadata: (metadata) => setMetadata(taskId, metadata),
+    getMetadata: store.getMetadata(taskId) as Effect.Effect<M>,
+    setMetadata: (metadata) => store.setMetadata(taskId, metadata),
     updateMetadata: (f) =>
-      Effect.flatMap(getMetadata(taskId), (current) => setMetadata(taskId, f(current as M))),
-    incrementSucceeded: (amount) => incrementSucceeded(taskId, amount),
-    incrementFailed: (amount) => incrementFailed(taskId, amount),
-    update: (options) => updateTask(taskId, options),
-    complete: completeTask(taskId),
-    fail: failTask(taskId),
-    getSnapshot: getTask(taskId).pipe(Effect.map(Option.getOrThrow)),
+      Effect.flatMap(store.getMetadata(taskId), (current) =>
+        store.setMetadata(taskId, f(current as M)),
+      ),
+    incrementSucceeded: (amount) => store.incrementSucceeded(taskId, amount),
+    incrementFailed: (amount) => store.incrementFailed(taskId, amount),
+    update: (options) => store.updateTask(taskId, options),
+    complete: store.completeTask(taskId),
+    fail: store.failTask(taskId),
+    getSnapshot: store.getTask(taskId).pipe(Effect.map(Option.getOrThrow)),
   });
 
   const autoFinalizeIfRunning = <E>(taskId: TaskId, exit: Exit.Exit<unknown, E>) =>
     Effect.gen(function* () {
-      const task = yield* getTask(taskId);
+      const task = yield* store.getTask(taskId);
       if (Option.isNone(task) || task.value.status !== "running") {
         return;
       }
 
       if (Exit.isSuccess(exit)) {
-        yield* completeTask(taskId);
+        yield* store.completeTask(taskId);
       } else {
-        yield* failTask(taskId);
+        yield* store.failTask(taskId);
       }
     });
 
@@ -136,16 +128,16 @@ const makeProgressService = Effect.gen(function* () {
 
   const service = {
     addTask,
-    updateTask,
-    incrementSucceeded,
-    incrementFailed,
-    completeTask,
-    failTask,
+    updateTask: store.updateTask,
+    incrementSucceeded: store.incrementSucceeded,
+    incrementFailed: store.incrementFailed,
+    completeTask: store.completeTask,
+    failTask: store.failTask,
     log,
-    getTask,
-    listTasks,
-    setMetadata,
-    getMetadata,
+    getTask: store.getTask,
+    listTasks: store.listTasks,
+    setMetadata: store.setMetadata,
+    getMetadata: store.getMetadata,
     task,
   } satisfies ProgressShape;
 

--- a/src/services/store/store.ts
+++ b/src/services/store/store.ts
@@ -5,6 +5,7 @@ import type {
   TaskProgressSample,
   TaskId,
   TaskStore,
+  TaskOperations,
   UpdateTaskOptions,
 } from "../../types";
 import { TaskId as makeTaskId, TaskSnapshot } from "../../types";
@@ -18,20 +19,10 @@ interface TaskCounts {
 const ETA_SAMPLE_WINDOW_MILLIS = 30_000;
 const ETA_SAMPLE_MAX_LENGTH = 1_000;
 
-export interface ProgressStoreShape {
+export interface ProgressStoreShape extends TaskOperations {
   readonly getSnapshot: () => TaskStore;
   readonly subscribe: (listener: () => void) => () => void;
   readonly flush: () => void;
-  readonly addTask: (options: AddTaskOptions<any>) => Effect.Effect<TaskId>;
-  readonly updateTask: (taskId: TaskId, options: UpdateTaskOptions) => Effect.Effect<void>;
-  readonly incrementSucceeded: (taskId: TaskId, amount?: number) => Effect.Effect<void>;
-  readonly incrementFailed: (taskId: TaskId, amount?: number) => Effect.Effect<void>;
-  readonly completeTask: (taskId: TaskId) => Effect.Effect<void>;
-  readonly failTask: (taskId: TaskId) => Effect.Effect<void>;
-  readonly getTask: (taskId: TaskId) => Effect.Effect<Option.Option<TaskSnapshot>>;
-  readonly listTasks: Effect.Effect<ReadonlyArray<TaskSnapshot>>;
-  readonly setMetadata: (taskId: TaskId, metadata: unknown) => Effect.Effect<void>;
-  readonly getMetadata: (taskId: TaskId) => Effect.Effect<unknown>;
 }
 
 const hasExplicitTotal = (options: Pick<AddTaskOptions | UpdateTaskOptions, "total">) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,18 +155,22 @@ export interface TaskStore {
   readonly columns: ReadonlyMap<TaskId, ReadonlyArray<ColumnDef<any, any>>>;
 }
 
-export interface ProgressShape {
-  readonly addTask: (options: AddTaskOptions<any>) => Effect.Effect<TaskId>;
+/** Task operations shared by the progress service and its backing store. */
+export interface TaskOperations {
+  readonly addTask: <M>(options: AddTaskOptions<M>) => Effect.Effect<TaskId>;
   readonly updateTask: (taskId: TaskId, options: UpdateTaskOptions) => Effect.Effect<void>;
   readonly incrementSucceeded: (taskId: TaskId, amount?: number) => Effect.Effect<void>;
   readonly incrementFailed: (taskId: TaskId, amount?: number) => Effect.Effect<void>;
   readonly completeTask: (taskId: TaskId) => Effect.Effect<void>;
   readonly failTask: (taskId: TaskId) => Effect.Effect<void>;
-  readonly log: (...args: ReadonlyArray<unknown>) => Effect.Effect<void>;
   readonly getTask: (taskId: TaskId) => Effect.Effect<Option.Option<TaskSnapshot>>;
   readonly listTasks: Effect.Effect<ReadonlyArray<TaskSnapshot>>;
   readonly setMetadata: (taskId: TaskId, metadata: unknown) => Effect.Effect<void>;
   readonly getMetadata: (taskId: TaskId) => Effect.Effect<unknown>;
+}
+
+export interface ProgressShape extends TaskOperations {
+  readonly log: (...args: ReadonlyArray<unknown>) => Effect.Effect<void>;
   /**
    * Runs an effect inside a newly created task scope.
    *


### PR DESCRIPTION
Depends on #33; this PR targets `codex/publish-snapshots-only` to keep the overlapping store-interface changes in order. The store stack is #32 → #33 → this PR.

## Problem

`ProgressShape` and `ProgressStoreShape` independently declare the same ten task operations. A signature change can drift between the service and store. The service also declares nine local aliases for store members and then forwards them again when constructing handles and its public shape.

## Solution

Define `TaskOperations` once and extend it from both interfaces. Keep service-specific `task`/`log` and store-specific snapshot/subscription methods on their respective interfaces. Reference store operations directly instead of creating aliases. Carry metadata through the shared `addTask` signature with a generic `M` instead of erasing it to `any`.

The service still wraps task creation to resolve the current parent. Existing public members remain available; `TaskOperations` is an additive type export.

## Examples

- A future change to `incrementSucceeded(taskId, amount?)` now has one declaration shared by the store and service.
- `addTask({ description: "upload", metadata: { bytes: 0 } })` carries its metadata type through parent resolution to the store.
- A handle's `complete` now references `store.completeTask(taskId)` directly, with the same underlying operation and lifecycle behavior.

## Validation

All 124 tests passed on this stack, including nested parent resolution, metadata-related task callbacks, terminal lifecycle behavior, and snapshot publication. Typecheck (including typed metadata examples), lint, formatting, and formatting check passed.
