### PR TITLE
refactor: centralize task finalization with exit handlers

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -123,20 +123,11 @@ const wrapTrackedEffect = <A, E, R>(
   taskId: TaskId,
   effect: Effect.Effect<A, E, R>,
 ) =>
-  Effect.gen(function* () {
-    const exit = yield* Effect.exit(effect);
-
+  Effect.onExit(effect, (exit) => {
     if (Exit.isSuccess(exit)) {
-      yield* progress.incrementSucceeded(taskId, 1);
-      return exit.value;
+      return progress.incrementSucceeded(taskId);
     }
-
-    if (Cause.hasInterruptsOnly(exit.cause)) {
-      return yield* Effect.failCause(exit.cause);
-    }
-
-    yield* progress.incrementFailed(taskId, 1);
-    return yield* Effect.failCause(exit.cause);
+    return Cause.hasInterruptsOnly(exit.cause) ? Effect.void : progress.incrementFailed(taskId);
   });
 
 const isTaskFullyProcessed = (progress: ProgressShape, taskId: TaskId) =>
@@ -173,36 +164,27 @@ export const all: {
         const progress = yield* Progress;
         return yield* progress.task(
           (handle) =>
-            Effect.gen(function* () {
-              const taskId = handle.id;
-              const exit = yield* Effect.exit(
-                Effect.all(
-                  wrapEffects(effects, (effect) => wrapTrackedEffect(progress, taskId, effect)),
-                  {
-                    concurrency: options.concurrency,
-                    discard: options.discard,
-                    mode: options.mode,
-                  },
-                ),
-              );
-
-              if (Exit.isSuccess(exit)) {
-                yield* progress.completeTask(taskId);
-              } else {
-                if (!isCollectAllMode(options.mode)) {
-                  yield* progress.failTask(taskId);
-                } else if (yield* isTaskFullyProcessed(progress, taskId)) {
-                  yield* progress.completeTask(taskId);
-                } else {
-                  yield* progress.failTask(taskId);
-                }
-              }
-
-              return yield* Exit.match(exit, {
-                onFailure: Effect.failCause,
-                onSuccess: Effect.succeed,
-              });
-            }),
+            Effect.onExit(
+              Effect.all(
+                wrapEffects(effects, (effect) => wrapTrackedEffect(progress, handle.id, effect)),
+                {
+                  concurrency: options.concurrency,
+                  discard: options.discard,
+                  mode: options.mode,
+                },
+              ),
+              (exit) =>
+                Effect.gen(function* () {
+                  // Result mode considers fully accounted work complete even after an abnormal exit.
+                  if (
+                    Exit.isFailure(exit) &&
+                    isCollectAllMode(options.mode) &&
+                    (yield* isTaskFullyProcessed(progress, handle.id))
+                  ) {
+                    yield* handle.complete;
+                  }
+                }),
+            ),
           {
             description: options.description,
             total: countEffects(effects),

--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -58,20 +58,6 @@ const makeProgressService = Effect.gen(function* () {
     getSnapshot: store.getTask(taskId).pipe(Effect.map(Option.getOrThrow)),
   });
 
-  const autoFinalizeIfRunning = <E>(taskId: TaskId, exit: Exit.Exit<unknown, E>) =>
-    Effect.gen(function* () {
-      const task = yield* store.getTask(taskId);
-      if (Option.isNone(task) || task.value.status !== "running") {
-        return;
-      }
-
-      if (Exit.isSuccess(exit)) {
-        yield* store.completeTask(taskId);
-      } else {
-        yield* store.failTask(taskId);
-      }
-    });
-
   const scopedTask = <A, E, R>(effect: Effect.Effect<A, E, R>, options: AddTaskOptions) =>
     Effect.gen(function* () {
       const taskId = yield* addTask(options);
@@ -94,18 +80,15 @@ const makeProgressService = Effect.gen(function* () {
       scopedTask(
         Effect.gen(function* () {
           const taskId = yield* Task;
-          const effect =
-            typeof effectOrCallback === "function"
-              ? effectOrCallback(makeTaskHandle(taskId))
-              : effectOrCallback;
-          const exit = yield* Effect.exit(effect);
-
-          yield* autoFinalizeIfRunning(taskId, exit);
-
-          return yield* Exit.match(exit, {
-            onFailure: Effect.failCause,
-            onSuccess: Effect.succeed,
-          });
+          return yield* Effect.onExit(
+            Effect.suspend(() =>
+              typeof effectOrCallback === "function"
+                ? effectOrCallback(makeTaskHandle(taskId))
+                : effectOrCallback,
+            ),
+            // Store finalization is terminal, so explicit completion/failure always wins.
+            (exit) => (Exit.isSuccess(exit) ? store.completeTask(taskId) : store.failTask(taskId)),
+          );
         }),
         options,
       ),

--- a/tests/task-finalization.test.ts
+++ b/tests/task-finalization.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { Deferred, Effect, Exit, Fiber } from "effect";
+import * as Progress from "../src";
+import { Renderer } from "../src/services/renderer/renderer";
+
+const withProgress = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  effect.pipe(
+    Effect.provide(Progress.Progress.layer),
+    Effect.provideService(Renderer, { run: Effect.never }),
+    Effect.scoped,
+  );
+
+describe("task exit finalization", () => {
+  test("finalizes a callback that throws before returning an Effect", async () => {
+    const defect = new Error("callback construction failed");
+    const { exit, tasks } = await Effect.runPromise(
+      withProgress(
+        Effect.gen(function* () {
+          const progress = yield* Progress.Progress;
+          const exit = yield* Effect.exit(
+            Progress.task(
+              (): Effect.Effect<void> => {
+                throw defect;
+              },
+              {
+                description: "callback",
+              },
+            ),
+          );
+          return { exit, tasks: yield* progress.listTasks };
+        }),
+      ),
+    );
+    expect(exit).toEqual(Exit.die(defect));
+    expect(tasks[0]?.status).toBe("failed");
+  });
+
+  test.each([
+    ["default", 1, "failed"],
+    ["result", 1, "done"],
+    ["result", 2, "failed"],
+  ] as const)("preserves defects in %s mode with %i units", async (mode, total, status) => {
+    const defect = new Error("work failed");
+    const { exit, tasks } = await Effect.runPromise(
+      withProgress(
+        Effect.gen(function* () {
+          const progress = yield* Progress.Progress;
+          const exit = yield* Effect.exit(
+            Progress.all(total === 1 ? [Effect.die(defect)] : [Effect.die(defect), Effect.void], {
+              description: "defect",
+              mode,
+            }),
+          );
+          return { exit, tasks: yield* progress.listTasks };
+        }),
+      ),
+    );
+    expect(exit).toEqual(Exit.die(defect));
+    expect(tasks[0]?.status).toBe(status);
+    expect(tasks[0]?.units).toEqual({ succeeded: 0, failed: 1, processed: 1, total });
+  });
+
+  test("interruption finalizes the parent without counting interrupted work", async () => {
+    const tasks = await Effect.runPromise(
+      withProgress(
+        Effect.gen(function* () {
+          const progress = yield* Progress.Progress;
+          const started = yield* Deferred.make<void>();
+          const fiber = yield* Effect.forkChild(
+            Progress.all(
+              [Deferred.succeed(started, undefined).pipe(Effect.andThen(Effect.never))],
+              { description: "interrupted", mode: "result" },
+            ),
+          );
+          yield* Deferred.await(started);
+          yield* Fiber.interrupt(fiber);
+          return yield* progress.listTasks;
+        }),
+      ),
+    );
+    expect(tasks[0]?.status).toBe("failed");
+    expect(tasks[0]?.units).toEqual({ succeeded: 0, failed: 0, processed: 0, total: 1 });
+  });
+});


### PR DESCRIPTION
## Problem

Tracked work and task scopes manually capture exits and re-emit their values/causes. `all` repeats normal completion/failure handling already owned by its enclosing task. The service also rechecks task status even though store finalization is already terminal. A callback that throws while constructing its Effect can escape the existing finalization boundary.

## Solution

Observe tracked outcomes with `Effect.onExit`, preserving their results and causes automatically. Let the task scope own normal lifecycle finalization, relying on the store to preserve explicit terminal outcomes. Retain `all`'s special rule: in result mode, an abnormal exit with every unit accounted for completes the task.

Construct callbacks inside `Effect.suspend` within the exit handler, so a synchronous callback throw also finalizes the task. Finalizer execution follows Effect's interruption-safe exit semantics.

## Examples

```ts
Progress.task(
  (): Effect.Effect<void> => { throw new Error("setup failed"); },
  { description: "Upload" },
);
```

Previously the task could remain running; now it becomes failed and the original defect propagates.

For `Progress.all([Effect.die(error)], { description: "One item", mode: "result" })`, the defect still propagates, the failed counter is 1, and the task is done because all work was accounted for. Add a second unstarted item and the task is failed with processed=1/total=2. Interrupting unfinished work leaves its counters unprocessed. Explicit `handle.complete` or `handle.fail` still wins over the callback outcome.

## Validation

125 tests pass, including focused callback-throw, defect, result-mode accounting, and interruption cases. Existing explicit-finalization and mixed-outcome tests pass. Typecheck, lint, formatter, Knip, and whitespace checks pass.
