### PR TITLE
refactor!: use Effect logging directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Effect.runPromise(program);
 
 - The Ink renderer runs with `patchConsole: true`, so console output is patched by Ink while the app is mounted.
 - `Effect.log*` uses the active Effect v4 `Logger` set, including custom loggers installed with `Logger.layer(...)`.
-- The low-level `progress.log(...)` method emits through `Effect.log`, so it honors the current log level, logger set, annotations, and spans.
+- Use `Effect.log(...)` or `Effect.logInfo(...)` directly; these honor the current log level, logger set, annotations, and spans. The former `progress.log(...)` alias has been removed.
 - Direct `Console` calls still use the currently provided Effect `Console` reference.
 - Formatting and routing remain controlled by the consumer's logger and console configuration.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Effect.runPromise(program);
 
 - The Ink renderer runs with `patchConsole: true`, so console output is patched by Ink while the app is mounted.
 - `Effect.log*` uses the active Effect v4 `Logger` set, including custom loggers installed with `Logger.layer(...)`.
-- Use `Effect.log(...)` or `Effect.logInfo(...)` directly; these honor the current log level, logger set, annotations, and spans. The former `progress.log(...)` alias has been removed.
+- Use `Effect.log(...)` or `Effect.logInfo(...)` directly; these honor the current log level, logger set, annotations, and spans.
 - Direct `Console` calls still use the currently provided Effect `Console` reference.
 - Formatting and routing remain controlled by the consumer's logger and console configuration.
 

--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -26,8 +26,6 @@ const makeProgressService = Effect.gen(function* () {
       : Option.none<TaskId>(),
   );
 
-  const log = (...args: ReadonlyArray<unknown>) => Effect.log(...args);
-
   yield* Effect.forkIn(inkRenderer.run, scope, { startImmediately: true });
   // Let the renderer fiber start so queued logs are reliably flushed on scope teardown.
   yield* Effect.sleep("0 millis");
@@ -118,7 +116,6 @@ const makeProgressService = Effect.gen(function* () {
     incrementFailed: store.incrementFailed,
     completeTask: store.completeTask,
     failTask: store.failTask,
-    log,
     getTask: store.getTask,
     listTasks: store.listTasks,
     setMetadata: store.setMetadata,

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,7 +170,6 @@ export interface TaskOperations {
 }
 
 export interface ProgressShape extends TaskOperations {
-  readonly log: (...args: ReadonlyArray<unknown>) => Effect.Effect<void>;
   /**
    * Runs an effect inside a newly created task scope.
    *

--- a/tests/task-scopes.test.ts
+++ b/tests/task-scopes.test.ts
@@ -129,54 +129,20 @@ describe("Progress task scopes", () => {
     expect(result).toBeTrue();
   });
 
-  test("task preserves Effect v4 loggers and routes Progress.log through them", async () => {
+  test("task preserves Effect v4 loggers", async () => {
     const { logs } = await Effect.runPromise(
       withLoggerSpy(
         withStdio(
-          Progress.task(
-            Effect.gen(function* () {
-              yield* Effect.logInfo("effect-log");
-              const progress = yield* Progress.Progress;
-              yield* progress.log("progress-log");
-            }),
-            { description: "logger-task", transient: true },
-          ),
+          Progress.task(Effect.logInfo("effect-log"), {
+            description: "logger-task",
+            transient: true,
+          }),
         ),
       ),
     );
-
-    const messages = logs.flatMap((entry) =>
-      Array.isArray(entry.message) ? entry.message : [entry.message],
-    );
-    expect(messages).toContain("effect-log");
-    expect(messages).toContain("progress-log");
-    expect(
-      logs.find((entry) =>
-        (Array.isArray(entry.message) ? entry.message : [entry.message]).includes("effect-log"),
-      )?.logLevel,
-    ).toBe("Info");
-  });
-
-  test("Progress.log forwards zero-argument calls to Effect loggers", async () => {
-    const { logs } = await Effect.runPromise(
-      withLoggerSpy(
-        withStdio(
-          Progress.task(
-            Effect.gen(function* () {
-              const progress = yield* Progress.Progress;
-              yield* progress.log();
-            }),
-            { description: "empty-log-message", transient: true },
-          ),
-        ),
-      ),
-    );
-
-    const emptyMessageLog = logs.find(
-      (entry) => Array.isArray(entry.message) && entry.message.length === 0,
-    );
-    expect(emptyMessageLog).toBeDefined();
-    expect(emptyMessageLog?.logLevel).toBe("Info");
+    expect(logs).toHaveLength(1);
+    expect(logs[0]?.message).toEqual(["effect-log"]);
+    expect(logs[0]?.logLevel).toBe("Info");
   });
 
   test("all returns the values from each effect", async () => {


### PR DESCRIPTION
## Problem

The service's `progress.log` method is a direct alias for `Effect.log`. It adds a public method, forwarding implementation, documentation, and alias-specific tests without different behavior.

## Solution

Remove the service alias and recommend `Effect.log` / `Effect.logInfo` in the README. Keep and simplify the test proving custom Effect loggers are honored while progress rendering is active. Ink console handling and standard Effect logging are unchanged.

This is a breaking API removal: migrate `progress.log(...)` calls to `Effect.log(...)`.

## Example

Before:

```ts
const progress = yield* Progress.Progress;
yield* progress.log("Uploaded", fileName);
```

After:

```ts
yield* Effect.log("Uploaded", fileName);
```

The same logger, log level, annotations, and spans apply; callers no longer need the Progress service just to log.

## Validation

119 tests pass, including custom logger and console integration checks. Typecheck, lint, formatter, Knip, and whitespace checks pass.
