### PR TITLE
refactor!: fix transient cleanup policy at task creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The handle exposes:
 
 - `incrementSucceeded(amount?)`
 - `incrementFailed(amount?)`
-- `update({ description, total, countDisplay, transient, succeeded, failed })`
+- `update({ description, total, countDisplay, succeeded, failed })`
 - `getMetadata`, `setMetadata`, `updateMetadata`
 - `getSnapshot`
 - `complete`
@@ -209,6 +209,8 @@ const program = Progress.task(
   { description: "Manual task", total: 10 },
 );
 ```
+
+Task cleanup policy is fixed at creation. Pass `transient: true` when creating a task to remove its subtree when it finishes. Children inherit a transient parent’s cleanup policy, and a child can opt into transient cleanup under a persistent parent. `updateTask` and `TaskHandle.update` no longer accept `transient`.
 
 Manual total behavior:
 

--- a/src/services/store/store.ts
+++ b/src/services/store/store.ts
@@ -119,7 +119,6 @@ const updatedSnapshot = (snapshot: TaskSnapshot, options: UpdateTaskOptions, now
     ...snapshot,
     description: options.description ?? snapshot.description,
     countDisplay: options.countDisplay ?? snapshot.countDisplay,
-    transient: options.transient ?? snapshot.transient,
     units,
     progressSamples: appendProgressSample(snapshot.progressSamples, now, units.processed),
   });
@@ -161,14 +160,6 @@ const findSubtreeRange = (renderOrder: TaskStore["renderOrder"], taskId: TaskId)
   }
 
   return { start, end };
-};
-
-const subtreeTaskIds = (
-  renderOrder: TaskStore["renderOrder"],
-  taskId: TaskId,
-): ReadonlyArray<TaskId> => {
-  const range = findSubtreeRange(renderOrder, taskId);
-  return range === undefined ? [] : renderOrder.slice(range.start, range.end).map((row) => row.id);
 };
 
 const removeTransientSubtree = (
@@ -427,18 +418,6 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
           const nextTask = updatedSnapshot(currentTask, options, now);
           const nextTasks = new Map(current.tasks);
           nextTasks.set(taskId, nextTask);
-
-          if (options.transient !== undefined) {
-            for (const candidateId of subtreeTaskIds(current.renderOrder, taskId).slice(1)) {
-              const candidate = current.tasks.get(candidateId);
-              if (!candidate) {
-                continue;
-              }
-
-              const nextCandidate = TaskSnapshot({ ...candidate, transient: nextTask.transient });
-              nextTasks.set(candidateId, nextCandidate);
-            }
-          }
 
           return { tasks: nextTasks, renderOrder: current.renderOrder, columns: current.columns };
         }, now);

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,7 @@ export interface TaskHandle<M> {
 export interface AddTaskOptions<M = void> {
   readonly description: string;
   readonly total?: number;
+  /** Cleanup policy is fixed at creation; a transient parent makes its descendants transient. */
   readonly transient?: boolean;
   readonly parentId?: TaskId;
   readonly countDisplay?: TaskCountDisplay;
@@ -103,7 +104,6 @@ export interface UpdateTaskOptions {
   readonly succeeded?: number;
   readonly failed?: number;
   readonly total?: number;
-  readonly transient?: boolean;
   readonly countDisplay?: TaskCountDisplay;
 }
 

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -92,42 +92,6 @@ describe("transient propagation", () => {
     expect(result.child.transient).toBeTrue();
   });
 
-  test("updating parent transient propagates to descendants", async () => {
-    const result = await Effect.runPromise(
-      withStdio(
-        withProgress(
-          Effect.gen(function* () {
-            const progress = yield* Progress.Progress;
-            const parentId = yield* progress.addTask({
-              description: "parent",
-              transient: false,
-            });
-            const childId = yield* progress.addTask({
-              description: "child",
-              parentId,
-            });
-            const grandchildId = yield* progress.addTask({
-              description: "grandchild",
-              parentId: childId,
-            });
-
-            yield* progress.updateTask(parentId, { transient: true });
-
-            const parent = getTaskOrFail(yield* progress.getTask(parentId), "parent");
-            const child = getTaskOrFail(yield* progress.getTask(childId), "child");
-            const grandchild = getTaskOrFail(yield* progress.getTask(grandchildId), "grandchild");
-
-            return { parent, child, grandchild };
-          }),
-        ),
-      ),
-    );
-
-    expect(result.parent.transient).toBeTrue();
-    expect(result.child.transient).toBeTrue();
-    expect(result.grandchild.transient).toBeTrue();
-  });
-
   test("transient child is removed on completion even under non-transient parent", async () => {
     const result = await Effect.runPromise(
       withStdio(


### PR DESCRIPTION
## Problem

Updating a parent's `transient` flag walks its entire subtree and overwrites every descendant's flag. Because only the effective value is stored, setting a parent back to false also erases a child's explicitly chosen transient policy.

## Solution

Make cleanup policy immutable after creation. Remove `transient` from `UpdateTaskOptions`, remove descendant-update traversal and its now-unused helper, and document the creation-time contract. Keep creation-time inheritance: transient parents make all descendants transient, and a child under a persistent parent can opt in.

This is a breaking change for `updateTask(..., { transient })` and `handle.update({ transient })`. Choose cleanup policy when creating the task.

## Example

```ts
const parent = yield* progress.addTask({ description: "Deploy" });
const child = yield* progress.addTask({
  description: "Temporary download",
  parentId: parent,
  transient: true,
});
yield* progress.updateTask(parent, { description: "Deploying release" });
yield* progress.completeTask(child);
```

The parent stays visible and the child is removed. Cleanup policy is no longer changed later via `progress.updateTask(parent, { transient: false })`.

## Validation

119 tests pass. Existing creation inheritance, transient-subtree removal, and neighbor-preservation tests remain. The test for the removed mutation feature was deleted. Typecheck, lint, formatter, Knip, and whitespace checks pass.
