### PR TITLE
test: share renderer fixtures and use real row derivation

### DIFF
--- a/tests/helpers/renderer.tsx
+++ b/tests/helpers/renderer.tsx
@@ -1,0 +1,62 @@
+import { renderToString } from "ink";
+import stripAnsi from "strip-ansi";
+import type { TaskSnapshot, TaskStore } from "../../src/types";
+import { TaskId } from "../../src/types";
+import { NowProvider } from "../../src/services/renderer/context/now-context";
+import { SpinnerProvider } from "../../src/services/renderer/context/spinner-context";
+import { ProgressRenderer } from "../../src/services/renderer/public-api";
+import { toRenderSnapshot } from "../../src/services/store/render-snapshot";
+import type { TaskRowModel } from "../../src/services/store/types";
+
+export const makeTaskSnapshot = (overrides: Partial<TaskSnapshot> = {}): TaskSnapshot => ({
+  id: TaskId(1),
+  parentId: null,
+  description: "task",
+  status: "running",
+  countDisplay: "processedOnly",
+  transient: false,
+  units: { succeeded: 1, failed: 0, processed: 1, total: 2 },
+  startedAt: 0,
+  completedAt: null,
+  progressSamples: [
+    { timestamp: 0, processed: 0 },
+    { timestamp: 1_000, processed: 1 },
+  ],
+  metadata: undefined,
+  ...overrides,
+});
+
+/** Exercise the real tree and width derivation instead of recreating it in fixtures. */
+export const makeRows = (
+  tasks: ReadonlyArray<TaskSnapshot>,
+  renderOrder: TaskStore["renderOrder"] = tasks.map(({ id }) => ({ id, depth: 0 })),
+): ReadonlyArray<TaskRowModel> =>
+  toRenderSnapshot({
+    tasks: new Map(tasks.map((task) => [task.id, task])),
+    renderOrder,
+    columns: new Map(),
+  }).rows;
+
+export const makeRow = (task: TaskSnapshot): TaskRowModel => makeRows([task])[0]!;
+
+export const renderRows = (
+  rows: ReadonlyArray<TaskRowModel>,
+  {
+    columns = new Map(),
+    now = 1_000,
+    spinnerTick = 0,
+  }: {
+    readonly columns?: TaskStore["columns"];
+    readonly now?: number;
+    readonly spinnerTick?: number;
+  } = {},
+): string =>
+  stripAnsi(
+    renderToString(
+      <NowProvider active={false} nowOverride={now}>
+        <SpinnerProvider active={false} tickOverride={spinnerTick}>
+          <ProgressRenderer rows={rows} columns={columns} />
+        </SpinnerProvider>
+      </NowProvider>,
+    ),
+  );

--- a/tests/renderer-description-column.test.tsx
+++ b/tests/renderer-description-column.test.tsx
@@ -1,147 +1,69 @@
 import { describe, expect, test } from "bun:test";
-import { renderToString } from "ink";
-import stripAnsi from "strip-ansi";
 import * as Progress from "../src";
-import { ProgressRenderer } from "../src/services/renderer/public-api";
-import { NowProvider } from "../src/services/renderer/context/now-context";
-import { SpinnerProvider } from "../src/services/renderer/context/spinner-context";
+import { makeTaskSnapshot, makeRows, renderRows } from "./helpers/renderer";
 import type { TaskRowModel } from "../src/services/store/types";
-
-const treePrefix = (tree: TaskRowModel["tree"]): string => {
-  if (tree.depth <= 0) {
-    return "";
-  }
-
-  return `${tree.ancestorHasNextSibling
-    .slice(1)
-    .map((hasNextSibling) => (hasNextSibling ? "│  " : "   "))
-    .join("")}${tree.hasNextSibling ? "├─ " : "└─ "}`;
-};
-
-const deriveRow = (task: Progress.TaskSnapshot, tree: TaskRowModel["tree"]): TaskRowModel => {
-  const prefix = treePrefix(tree);
-
-  return {
-    task,
-    tree,
-    derived: {
-      treePrefix: prefix,
-      treePrefixWidth: prefix.length,
-      descriptionWidth: task.description.length,
-      treePrefixedDescriptionWidth: prefix.length + task.description.length,
-      hasRenderableProgress: task.units.total !== undefined || task.units.processed > 0,
-      isDeterminate: task.units.total !== undefined,
-    },
-  };
-};
 
 const makeTask = (
   id: number,
   description: string,
-  status: Progress.TaskSnapshot["status"] = "done",
+  status: Progress.TaskStatus = "done",
+  parentId: Progress.TaskId | null = null,
 ): Progress.TaskSnapshot =>
-  Progress.TaskSnapshot({
+  makeTaskSnapshot({
     id: Progress.TaskId(id),
-    parentId: null,
+    parentId,
     description,
     status,
-    countDisplay: "processedOnly",
-    transient: false,
-    units: {
-      succeeded: 1,
-      failed: 0,
-      processed: 1,
-      total: 1,
-    },
-    startedAt: 0,
+    units: { succeeded: 1, failed: 0, processed: 1, total: 1 },
     completedAt: status === "running" ? null : 1_000,
-    progressSamples: [
-      { timestamp: 0, processed: 0 },
-      { timestamp: 1_000, processed: 1 },
-    ],
-    metadata: undefined,
   });
 
-const renderDescriptionColumn = (rows: ReadonlyArray<TaskRowModel>, spinnerTick?: number): string =>
-  stripAnsi(
-    renderToString(
-      <NowProvider active={false} nowOverride={0}>
-        <SpinnerProvider active={false} tickOverride={spinnerTick}>
-          <ProgressRenderer
-            rows={rows}
-            columns={new Map(rows.map((row) => [row.task.id, [Progress.Columns.description()]]))}
-          />
-        </SpinnerProvider>
-      </NowProvider>,
-    ),
-  );
+const renderDescriptionColumn = (rows: ReadonlyArray<TaskRowModel>, spinnerTick = 0): string =>
+  renderRows(rows, {
+    now: 0,
+    spinnerTick,
+    columns: new Map(rows.map((row) => [row.task.id, [Progress.Columns.description()]])),
+  });
 
 describe("renderer description tree planning", () => {
   test("renders the spinner after the tree prefix", () => {
-    const rows = [
-      deriveRow(makeTask(1, "root", "running"), {
-        depth: 0,
-        hasChildren: true,
-        hasNextSibling: false,
-        ancestorHasNextSibling: [],
-      }),
-      deriveRow(makeTask(2, "child task", "running"), {
-        depth: 1,
-        hasChildren: false,
-        hasNextSibling: false,
-        ancestorHasNextSibling: [false],
-      }),
-    ];
+    const rows = makeRows(
+      [makeTask(1, "root", "running"), makeTask(2, "child task", "running", Progress.TaskId(1))],
+      [
+        { id: Progress.TaskId(1), depth: 0 },
+        { id: Progress.TaskId(2), depth: 1 },
+      ],
+    );
 
     const output = renderDescriptionColumn(rows);
-
-    expect(output.includes("⠋ root")).toBeTrue();
-    expect(output.includes("└─ ⠋ child")).toBeTrue();
-    expect(output.includes("⠋ └─")).toBeFalse();
+    expect(output).toContain("⠋ root");
+    expect(output).toContain("└─ ⠋ child");
+    expect(output).not.toContain("⠋ └─");
   });
 
   test("uses the spinner context instead of a renderer tick prop", () => {
-    const rows = [
-      deriveRow(makeTask(1, "root", "running"), {
-        depth: 0,
-        hasChildren: false,
-        hasNextSibling: false,
-        ancestorHasNextSibling: [],
-      }),
-    ];
-
-    const output = renderDescriptionColumn(rows, 2);
-
-    expect(output.includes("⠹ root")).toBeTrue();
-    expect(output.includes("⠋ root")).toBeFalse();
+    const output = renderDescriptionColumn(makeRows([makeTask(1, "root", "running")]), 2);
+    expect(output).toContain("⠹ root");
+    expect(output).not.toContain("⠋ root");
   });
 
   test("renders tree prefixes for nested tasks", () => {
-    const rows = [
-      deriveRow(makeTask(1, "root"), {
-        depth: 0,
-        hasChildren: true,
-        hasNextSibling: false,
-        ancestorHasNextSibling: [],
-      }),
-      deriveRow(makeTask(2, "child"), {
-        depth: 1,
-        hasChildren: true,
-        hasNextSibling: false,
-        ancestorHasNextSibling: [false],
-      }),
-      deriveRow(makeTask(3, "grandchild"), {
-        depth: 2,
-        hasChildren: false,
-        hasNextSibling: false,
-        ancestorHasNextSibling: [false, false],
-      }),
-    ];
+    const rows = makeRows(
+      [
+        makeTask(1, "root"),
+        makeTask(2, "child", "done", Progress.TaskId(1)),
+        makeTask(3, "grandchild", "done", Progress.TaskId(2)),
+      ],
+      [
+        { id: Progress.TaskId(1), depth: 0 },
+        { id: Progress.TaskId(2), depth: 1 },
+        { id: Progress.TaskId(3), depth: 2 },
+      ],
+    );
 
     const output = renderDescriptionColumn(rows);
-
     expect(output).toContain("✓ root");
     expect(output).toContain("└─ ✓ child");
-    expect(output).toContain("└─ ✓ grandchild");
+    expect(output).toContain("   └─ ✓ grandchild");
   });
 });

--- a/tests/renderer-eta-column.test.tsx
+++ b/tests/renderer-eta-column.test.tsx
@@ -1,71 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import { renderToString } from "ink";
-import stripAnsi from "strip-ansi";
 import * as Progress from "../src";
-import { NowProvider } from "../src/services/renderer/context/now-context";
-import { SpinnerProvider } from "../src/services/renderer/context/spinner-context";
-import { ProgressRenderer } from "../src/services/renderer/public-api";
-import type { TaskRowModel } from "../src/services/store/types";
-
-const deriveRow = (task: Progress.TaskSnapshot): TaskRowModel => ({
-  task,
-  tree: {
-    depth: 0,
-    hasChildren: false,
-    hasNextSibling: false,
-    ancestorHasNextSibling: [],
-  },
-  derived: {
-    treePrefix: "",
-    treePrefixWidth: 0,
-    descriptionWidth: task.description.length,
-    treePrefixedDescriptionWidth: task.description.length,
-    hasRenderableProgress: task.units.total !== undefined || task.units.processed > 0,
-    isDeterminate: task.units.total !== undefined,
-  },
-});
+import { makeTaskSnapshot, makeRow as deriveRow, renderRows } from "./helpers/renderer";
 
 const makeTask = (overrides: Partial<Progress.TaskSnapshot> = {}): Progress.TaskSnapshot =>
-  Progress.TaskSnapshot({
-    id: Progress.TaskId(1),
-    parentId: null,
-    description: "eta-task",
-    status: "running",
-    countDisplay: "processedOnly",
-    transient: false,
-    units: {
-      succeeded: 1,
-      failed: 0,
-      processed: 1,
-      total: 2,
-    },
-    startedAt: 0,
-    completedAt: null,
-    progressSamples: [
-      { timestamp: 0, processed: 0 },
-      { timestamp: 1_000, processed: 1 },
-    ],
-    metadata: undefined,
-    ...overrides,
-  });
+  makeTaskSnapshot({ description: "eta-task", ...overrides });
 
 const renderTaskWithEta = (task: Progress.TaskSnapshot, now: number): string =>
-  stripAnsi(
-    renderToString(
-      <NowProvider active={false} nowOverride={now}>
-        <SpinnerProvider active={false} tickOverride={0}>
-          <ProgressRenderer
-            rows={[deriveRow(task)]}
-            columns={
-              new Map<Progress.TaskId, ReadonlyArray<Progress.ColumnDef<any, any>>>([
-                [Progress.TaskId(1), [Progress.Columns.description(), Progress.Columns.eta()]],
-              ])
-            }
-          />
-        </SpinnerProvider>
-      </NowProvider>,
-    ),
-  );
+  renderRows([deriveRow(task)], {
+    now,
+    columns: new Map([[task.id, [Progress.Columns.description(), Progress.Columns.eta()]]]),
+  });
 
 const renderWithEta = (now: number): string => renderTaskWithEta(makeTask(), now);
 
@@ -76,37 +20,17 @@ describe("renderer eta column", () => {
   });
 
   test("does not render ETA for completed tasks", () => {
-    const completedTask = Progress.TaskSnapshot({
-      id: Progress.TaskId(1),
-      parentId: null,
+    const completedTask = makeTask({
       description: "done-task",
       status: "done",
-      countDisplay: "processedOnly",
-      transient: false,
-      units: {
-        succeeded: 2,
-        failed: 0,
-        processed: 2,
-        total: 2,
-      },
-      startedAt: 0,
+      units: { succeeded: 2, failed: 0, processed: 2, total: 2 },
       completedAt: 1_000,
       progressSamples: [
         { timestamp: 0, processed: 0 },
         { timestamp: 1_000, processed: 2 },
       ],
-      metadata: undefined,
     });
-
-    const output = stripAnsi(
-      renderToString(
-        <NowProvider active={false} nowOverride={1_000}>
-          <SpinnerProvider active={false} tickOverride={0}>
-            <ProgressRenderer rows={[deriveRow(completedTask)]} columns={new Map()} />
-          </SpinnerProvider>
-        </NowProvider>,
-      ),
-    );
+    const output = renderTaskWithEta(completedTask, 1_000);
 
     expect(output).not.toContain("ETA:");
   });

--- a/tests/renderer-progress-columns.test.tsx
+++ b/tests/renderer-progress-columns.test.tsx
@@ -1,29 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { renderToString } from "ink";
-import stripAnsi from "strip-ansi";
 import * as Progress from "../src";
-import { NowProvider } from "../src/services/renderer/context/now-context";
-import { ProgressRenderer } from "../src/services/renderer/public-api";
-import { SpinnerProvider } from "../src/services/renderer/context/spinner-context";
-import type { TaskRowModel } from "../src/services/store/types";
-
-const deriveRow = (task: Progress.TaskSnapshot): TaskRowModel => ({
-  task,
-  tree: {
-    depth: 0,
-    hasChildren: false,
-    hasNextSibling: false,
-    ancestorHasNextSibling: [],
-  },
-  derived: {
-    treePrefix: "",
-    treePrefixWidth: 0,
-    descriptionWidth: task.description.length,
-    treePrefixedDescriptionWidth: task.description.length,
-    hasRenderableProgress: task.units.total !== undefined || task.units.processed > 0,
-    isDeterminate: task.units.total !== undefined,
-  },
-});
+import { makeTaskSnapshot, makeRow as deriveRow, renderRows } from "./helpers/renderer";
 
 const makeTask = (
   id: number,
@@ -31,37 +8,22 @@ const makeTask = (
   countDisplay: Progress.TaskCountDisplay,
   units: Progress.TaskSnapshot["units"],
 ): Progress.TaskSnapshot =>
-  Progress.TaskSnapshot({
+  makeTaskSnapshot({
     id: Progress.TaskId(id),
-    parentId: null,
     description,
-    status: units.total !== undefined && units.processed < units.total ? "failed" : "done",
     countDisplay,
-    transient: false,
     units,
-    startedAt: 0,
+    status: units.total !== undefined && units.processed < units.total ? "failed" : "done",
     completedAt: 1_000,
     progressSamples: [
       { timestamp: 0, processed: 0 },
       { timestamp: 1_000, processed: units.processed },
     ],
-    metadata: undefined,
   });
-
-const renderColumns = (rows: ReadonlyArray<TaskRowModel>): string =>
-  stripAnsi(
-    renderToString(
-      <NowProvider active={false} nowOverride={1_000}>
-        <SpinnerProvider active={false} tickOverride={0}>
-          <ProgressRenderer rows={rows} columns={new Map()} />
-        </SpinnerProvider>
-      </NowProvider>,
-    ),
-  );
 
 describe("renderer progress columns", () => {
   test("renders amount values for all rows", () => {
-    const output = renderColumns([
+    const output = renderRows([
       deriveRow(
         makeTask(1, "fail-fast", "processedOnly", {
           succeeded: 3,
@@ -85,7 +47,7 @@ describe("renderer progress columns", () => {
   });
 
   test("renders amounts with consistent formatting across rows", () => {
-    const output = renderColumns([
+    const output = renderRows([
       deriveRow(
         makeTask(1, "all-succeeded", "detailed", {
           succeeded: 3,

--- a/tests/renderer-public-api.test.tsx
+++ b/tests/renderer-public-api.test.tsx
@@ -1,30 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { renderToString } from "ink";
-import stripAnsi from "strip-ansi";
 import * as Progress from "../src";
+import { makeTaskSnapshot, makeRow as deriveRow, renderRows } from "./helpers/renderer";
 import { resolveColumns } from "../src/services/renderer/column-resolver";
-import { NowProvider } from "../src/services/renderer/context/now-context";
-import { ProgressRenderer } from "../src/services/renderer/public-api";
-import { SpinnerProvider } from "../src/services/renderer/context/spinner-context";
 import type { TaskRowModel } from "../src/services/store/types";
-
-const deriveRow = (task: Progress.TaskSnapshot): TaskRowModel => ({
-  task,
-  tree: {
-    depth: 0,
-    hasChildren: false,
-    hasNextSibling: false,
-    ancestorHasNextSibling: [],
-  },
-  derived: {
-    treePrefix: "",
-    treePrefixWidth: 0,
-    descriptionWidth: task.description.length,
-    treePrefixedDescriptionWidth: task.description.length,
-    hasRenderableProgress: task.units.total !== undefined || task.units.processed > 0,
-    isDeterminate: task.units.total !== undefined,
-  },
-});
 
 const makeTask = (
   id: number,
@@ -32,43 +10,13 @@ const makeTask = (
   metadata?: unknown,
   overrides: Partial<Progress.TaskSnapshot> = {},
 ): Progress.TaskSnapshot =>
-  Progress.TaskSnapshot({
-    id: Progress.TaskId(id),
-    parentId: null,
-    description,
-    status: "running",
-    countDisplay: "processedOnly",
-    transient: false,
-    units: {
-      succeeded: 1,
-      failed: 0,
-      processed: 1,
-      total: 2,
-    },
-    startedAt: 0,
-    completedAt: null,
-    progressSamples: [
-      { timestamp: 0, processed: 0 },
-      { timestamp: 1_000, processed: 1 },
-    ],
-    metadata,
-    ...overrides,
-  });
+  makeTaskSnapshot({ id: Progress.TaskId(id), description, metadata, ...overrides });
 
 const renderWithColumns = (
   rows: ReadonlyArray<TaskRowModel>,
-  columns: Map<Progress.TaskId, ReadonlyArray<Progress.ColumnDef<any, any>>>,
-  nowOverride = 1_000,
-): string =>
-  stripAnsi(
-    renderToString(
-      <NowProvider active={false} nowOverride={nowOverride}>
-        <SpinnerProvider active={false} tickOverride={0}>
-          <ProgressRenderer rows={rows} columns={columns} />
-        </SpinnerProvider>
-      </NowProvider>,
-    ),
-  );
+  columns: Progress.TaskStore["columns"],
+  now = 1_000,
+): string => renderRows(rows, { columns, now });
 
 describe("renderer public api", () => {
   test("renders null when there are no rows", () => {

--- a/tests/renderer-rows.test.tsx
+++ b/tests/renderer-rows.test.tsx
@@ -1,63 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import { renderToString } from "ink";
-import stripAnsi from "strip-ansi";
 import * as Progress from "../src";
-import { NowProvider } from "../src/services/renderer/context/now-context";
-import { SpinnerProvider } from "../src/services/renderer/context/spinner-context";
-import { ProgressRenderer } from "../src/services/renderer/public-api";
-import type { TaskRowModel } from "../src/services/store/types";
-
-const deriveRow = (task: Progress.TaskSnapshot): TaskRowModel => ({
-  task,
-  tree: {
-    depth: 0,
-    hasChildren: false,
-    hasNextSibling: false,
-    ancestorHasNextSibling: [],
-  },
-  derived: {
-    treePrefix: "",
-    treePrefixWidth: 0,
-    descriptionWidth: task.description.length,
-    treePrefixedDescriptionWidth: task.description.length,
-    hasRenderableProgress: task.units.total !== undefined || task.units.processed > 0,
-    isDeterminate: task.units.total !== undefined,
-  },
-});
+import { makeTaskSnapshot, makeRow as deriveRow, renderRows } from "./helpers/renderer";
 
 const makeTask = (id: number): Progress.TaskSnapshot =>
-  Progress.TaskSnapshot({
+  makeTaskSnapshot({
     id: Progress.TaskId(id),
-    parentId: null,
     description: `task-${id}`,
     status: "done",
-    countDisplay: "processedOnly",
-    transient: false,
-    units: {
-      succeeded: 1,
-      failed: 0,
-      processed: 1,
-      total: 1,
-    },
-    startedAt: 0,
+    units: { succeeded: 1, failed: 0, processed: 1, total: 1 },
     completedAt: 1_000,
-    progressSamples: [
-      { timestamp: 0, processed: 0 },
-      { timestamp: 1_000, processed: 1 },
-    ],
-    metadata: undefined,
   });
-
-const renderRows = (rows: ReadonlyArray<TaskRowModel>): string =>
-  stripAnsi(
-    renderToString(
-      <NowProvider active={false} nowOverride={0}>
-        <SpinnerProvider active={false} tickOverride={0}>
-          <ProgressRenderer rows={rows} columns={new Map()} />
-        </SpinnerProvider>
-      </NowProvider>,
-    ),
-  ).trimEnd();
 
 describe("renderer row rendering", () => {
   test("renders all rows directly without virtual scrolling", () => {


### PR DESCRIPTION
## Problem

Five renderer suites independently construct full snapshots, derived rows, tree prefixes, and provider-wrapped string renderers. Their copied width calculations use string length rather than terminal display width. The completed-ETA test also asserts that `ETA:` is absent while rendering default columns, which do not include the standalone ETA column.

## Solution

Add shared snapshot, row, and render helpers. Generate rows through `toRenderSnapshot` so renderer tests use production tree/width derivation, while keeping dedicated snapshot tests for the derivation itself. Centralize fixed clock/spinner setup and render the actual ETA column in the completed-task test.

Retain public derived/tree fields because they are available to custom column consumers; this PR removes duplicated fixture construction without removing that API.

## Example

```ts
const task = makeTaskSnapshot({ description: "下載", status: "running" });
const rows = makeRows([task]);
const output = renderRows(rows, { now: 1_000, spinnerTick: 2 });
```

Nested fixtures supply depth-first render order:

```ts
makeRows([parent, child], [
  { id: parent.id, depth: 0 },
  { id: child.id, depth: 1 },
]);
```

The production snapshot builder supplies `└─ ` and display widths; tests no longer reproduce those rules.

## Validation

120 tests pass, including all migrated renderer suites and the corrected ETA assertion. Typecheck, lint, formatter, Knip, and whitespace checks pass.
