### PR TITLE
refactor: share amount presentation across formatting and rendering

### DIFF
--- a/src/services/renderer/columns/amount-column.tsx
+++ b/src/services/renderer/columns/amount-column.tsx
@@ -1,7 +1,6 @@
 import { Text } from "ink";
 import type { CellInfo, TaskSnapshot } from "../../../types";
-import { isDeterminate } from "../shared/determinate";
-import { formatAmount } from "../shared/format";
+import { getAmountParts } from "../shared/amount-parts";
 import { textWidth } from "../shared/text-width";
 
 export interface AmountLayout {
@@ -12,77 +11,36 @@ export interface AmountLayout {
   readonly preferredWidth: number;
 }
 
-const hasUnknownTotalCounts = (task: TaskSnapshot): boolean =>
-  task.units.total === undefined && task.units.processed > 0;
-
-const hasCountedAmount = (task: TaskSnapshot): boolean =>
-  isDeterminate(task) || hasUnknownTotalCounts(task);
-
-const totalTextFor = (task: TaskSnapshot): string =>
-  task.units.total === undefined ? "?" : `${task.units.total}`;
-
-const emptyAmountLayout: AmountLayout = {
-  hasDetailedRows: false,
-  countWidth: 0,
-  processedWidth: 0,
-  totalWidth: 0,
-  preferredWidth: 0,
-};
-
 export const measureAmountLayout = (rows: ReadonlyArray<CellInfo<unknown>>): AmountLayout => {
-  const countedTasks = rows.flatMap((row) => (hasCountedAmount(row.task) ? [row.task] : []));
-  const hasDetailedRows = countedTasks.some((task) => task.countDisplay === "detailed");
+  let hasDetailedRows = false;
+  let countWidth = 0;
+  let processedWidth = 0;
+  let totalWidth = 0;
+  let indicatorWidth = 0;
 
-  if (countedTasks.length === 0) {
-    const preferredWidth = rows.reduce(
-      (max, row) => Math.max(max, textWidth(formatAmount(row.task))),
-      0,
-    );
-
-    return {
-      ...emptyAmountLayout,
-      preferredWidth,
-    };
+  for (const row of rows) {
+    const parts = getAmountParts(row.task);
+    if (parts.kind === "indicator") {
+      indicatorWidth = Math.max(indicatorWidth, textWidth(parts.text));
+      continue;
+    }
+    hasDetailedRows ||= parts.detailed;
+    processedWidth = Math.max(processedWidth, parts.processed.length);
+    totalWidth = Math.max(totalWidth, parts.total.length);
+    countWidth = Math.max(countWidth, parts.succeeded.length, parts.failed.length);
   }
 
-  const processedWidth = countedTasks.reduce(
-    (max, task) => Math.max(max, `${task.units.processed}`.length),
-    1,
-  );
-  const totalWidth = countedTasks.reduce(
-    (max, task) => Math.max(max, totalTextFor(task).length),
-    1,
-  );
-  const countWidth = hasDetailedRows
-    ? countedTasks.reduce(
-        (max, task) =>
-          Math.max(
-            max,
-            processedWidth,
-            totalWidth,
-            `${task.units.succeeded}`.length,
-            `${task.units.failed}`.length,
-          ),
-        1,
-      )
-    : 0;
-
+  countWidth = hasDetailedRows ? Math.max(countWidth, processedWidth, totalWidth) : 0;
   const countedWidth =
-    (hasDetailedRows ? countWidth + 1 + countWidth + 1 : 0) + processedWidth + 1 + totalWidth;
-  const preferredWidth = rows.reduce((max, row) => {
-    if (hasCountedAmount(row.task)) {
-      return Math.max(max, countedWidth);
-    }
-
-    return Math.max(max, textWidth(formatAmount(row.task)));
-  }, countedWidth);
-
+    processedWidth === 0
+      ? 0
+      : (hasDetailedRows ? 2 * (countWidth + 1) : 0) + processedWidth + 1 + totalWidth;
   return {
     hasDetailedRows,
     countWidth,
     processedWidth,
     totalWidth,
-    preferredWidth,
+    preferredWidth: Math.max(indicatorWidth, countedWidth),
   };
 };
 
@@ -93,23 +51,24 @@ const AmountValue = ({
   readonly task: TaskSnapshot;
   readonly layout: AmountLayout;
 }) => {
-  if (!hasCountedAmount(task)) {
-    return formatAmount(task);
+  const parts = getAmountParts(task);
+  if (parts.kind === "indicator") {
+    return parts.text;
   }
 
-  const processed = `${task.units.processed}`.padStart(layout.processedWidth, " ");
-  const total = totalTextFor(task).padStart(layout.totalWidth, " ");
+  const processed = parts.processed.padStart(layout.processedWidth, " ");
+  const total = parts.total.padStart(layout.totalWidth, " ");
 
   if (!layout.hasDetailedRows) {
     return `${processed}/${total}`;
   }
 
-  if (task.countDisplay !== "detailed") {
+  if (!parts.detailed) {
     return `${" ".repeat(layout.countWidth)} ${" ".repeat(layout.countWidth)} ${processed}/${total}`;
   }
 
-  const succeeded = `${task.units.succeeded}`.padStart(layout.countWidth, " ");
-  const failed = `${task.units.failed}`.padStart(layout.countWidth, " ");
+  const succeeded = parts.succeeded.padStart(layout.countWidth, " ");
+  const failed = parts.failed.padStart(layout.countWidth, " ");
 
   return (
     <>

--- a/src/services/renderer/shared/amount-parts.ts
+++ b/src/services/renderer/shared/amount-parts.ts
@@ -1,0 +1,30 @@
+import type { TaskSnapshot } from "../../../types";
+
+type AmountParts =
+  | { readonly kind: "indicator"; readonly text: string }
+  | {
+      readonly kind: "counts";
+      readonly detailed: boolean;
+      readonly succeeded: string;
+      readonly failed: string;
+      readonly processed: string;
+      readonly total: string;
+    };
+
+/** One presentation model shared by plain text, layout measurement, and colored cells. */
+export const getAmountParts = (task: TaskSnapshot): AmountParts => {
+  const { succeeded, failed, processed, total } = task.units;
+  if (total === undefined && !(processed > 0)) {
+    return { kind: "indicator", text: task.status === "failed" ? "✗" : "" };
+  }
+  const totalText = total === undefined ? "?" : String(total);
+  const countWidth = total === undefined ? 0 : totalText.length;
+  return {
+    kind: "counts",
+    detailed: task.countDisplay === "detailed",
+    succeeded: String(succeeded).padStart(countWidth, " "),
+    failed: String(failed).padStart(countWidth, " "),
+    processed: String(processed),
+    total: totalText,
+  };
+};

--- a/src/services/renderer/shared/format.ts
+++ b/src/services/renderer/shared/format.ts
@@ -1,8 +1,6 @@
 import type { TaskSnapshot } from "../../../types";
 import { isDeterminate } from "./determinate";
-
-const showsUnknownTotalCounts = (task: TaskSnapshot): boolean =>
-  task.units.total === undefined && task.units.processed > 0;
+import { getAmountParts } from "./amount-parts";
 
 const formatDurationSeconds = (seconds: number): string => {
   const value = Math.max(0, Math.floor(seconds));
@@ -99,53 +97,11 @@ const formatEtaClock = (task: TaskSnapshot): string | undefined => {
 export const formatElapsedEta = (task: TaskSnapshot, now: number): string =>
   `${formatElapsedClock(task, now)}<${formatEtaClock(task) ?? "00:00"}`;
 
-interface DeterminateAmountParts {
-  readonly succeeded: string;
-  readonly failed: string;
-  readonly processed: string;
-  readonly total: string;
-}
-
-const formatDeterminateAmountParts = (task: TaskSnapshot): DeterminateAmountParts | undefined => {
-  if (!isDeterminate(task)) {
-    return undefined;
-  }
-
-  const totalText = `${task.units.total}`;
-  const width = totalText.length;
-  const processedText = `${task.units.processed}`;
-
-  return {
-    succeeded:
-      task.countDisplay === "detailed" ? `${task.units.succeeded}`.padStart(width, " ") : "",
-    failed: task.countDisplay === "detailed" ? `${task.units.failed}`.padStart(width, " ") : "",
-    processed: processedText,
-    total: totalText,
-  };
-};
-
 export const formatAmount = (task: TaskSnapshot): string => {
-  if (isDeterminate(task)) {
-    const parts = formatDeterminateAmountParts(task);
-    if (parts === undefined) {
-      return "";
-    }
-    if (task.countDisplay === "detailed") {
-      return `${parts.succeeded} ${parts.failed} ${parts.processed}/${parts.total}`;
-    }
-    return `${parts.processed}/${parts.total}`;
+  const parts = getAmountParts(task);
+  if (parts.kind === "indicator") {
+    return parts.text;
   }
-
-  if (showsUnknownTotalCounts(task)) {
-    if (task.countDisplay === "detailed") {
-      return `${task.units.succeeded} ${task.units.failed} ${task.units.processed}/?`;
-    }
-    return `${task.units.processed}/?`;
-  }
-
-  if (task.status === "running") {
-    return "";
-  }
-
-  return task.status === "failed" ? "✗" : "";
+  const processed = `${parts.processed}/${parts.total}`;
+  return parts.detailed ? `${parts.succeeded} ${parts.failed} ${processed}` : processed;
 };


### PR DESCRIPTION
## Problem

Plain amount formatting and styled cells separately decide whether counts exist, format unknown totals, and produce succeeded/failed/processed values. Layout measurement repeats those decisions across several array passes. This makes presentation rules easy to change in one path but miss in another.

## Solution

Introduce an internal discriminated amount-parts model for counts versus an indicator. Use it for plain formatting, width measurement, and colored rendering. Measure widths in one pass while preserving shared alignment, detailed/processed-only rows, unknown totals, and overflow counts.

## Examples

- Detailed succeeded=3, failed=1, total=4 remains `3 1 4/4`, with successes green and failures red in Ink.
- An unknown total with processed=4 remains `4/?` in processed-only mode.
- Known total=0 remains `0/0`; failed uncounted work remains `✗`.
- Mixed detailed and processed-only rows still reserve matching count columns and align the slash.

Plain text and styled cells now obtain their count strings and unknown-total decisions from the same function.

## Validation

120 tests pass, including amount formatting, zero/overflow/unknown totals, mixed outcomes, slash alignment, and narrow-terminal rendering. Typecheck, lint, formatter, Knip, and whitespace checks pass.
