### PR TITLE
refactor: share task overloads and Effect all return inference

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -7,29 +7,12 @@ import type {
   AddTaskOptions,
   ProgressShape,
   TaskCountDisplay,
+  TaskApi,
   TaskHandle,
   TaskId,
   TrackOptions,
 } from "./types";
 import { inferTotal } from "./utils";
-
-interface PublicTaskApi {
-  <A, E, R>(
-    effect: Effect.Effect<A, E, R>,
-    options: AddTaskOptions,
-  ): Effect.Effect<A, E, Exclude<R, Progress | Task>>;
-  <A, E, R>(
-    options: AddTaskOptions,
-  ): (effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Progress | Task>>;
-  <A, E, R>(
-    f: (handle: TaskHandle<void>) => Effect.Effect<A, E, R>,
-    options: AddTaskOptions<void>,
-  ): Effect.Effect<A, E, Exclude<R, Progress | Task>>;
-  <M, A, E, R>(
-    f: (handle: TaskHandle<M>) => Effect.Effect<A, E, R>,
-    options: AddTaskOptions<M> & { readonly metadata: M },
-  ): Effect.Effect<A, E, Exclude<R, Progress | Task>>;
-}
 
 const provideProgress = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   Effect.gen(function* () {
@@ -55,13 +38,7 @@ export type AllReturn<
     | ReadonlyArray<Effect.Effect<any, any, any>>
     | Record<string, Effect.Effect<any, any, any>>,
   O extends EffectAllExecutionOptions,
-> = [
-  [Arg] extends [ReadonlyArray<Effect.Effect<any, any, any>>]
-    ? Effect.All.ReturnTuple<Arg, Effect.All.IsDiscard<O>, Effect.All.IsResult<O>>
-    : [Arg] extends [Record<string, Effect.Effect<any, any, any>>]
-      ? Effect.All.ReturnObject<Arg, Effect.All.IsDiscard<O>, Effect.All.IsResult<O>>
-      : never,
-] extends [Effect.Effect<infer A, infer E, infer R>]
+> = [Effect.All.Return<Arg, O>] extends [Effect.Effect<infer A, infer E, infer R>]
   ? Effect.Effect<A, E, Exclude<R, Progress | Task>>
   : never;
 
@@ -81,7 +58,7 @@ export type TaskOptions<M = void> = AddTaskOptions<M>;
  * typed `TaskHandle` for task-local updates, typed metadata, and explicit completion or failure,
  * and otherwise auto-finalizes from the callback exit if the task is still `running`.
  */
-export const task: PublicTaskApi = dual(
+export const task: TaskApi<Progress | Task> = dual(
   2,
   <A, E, R>(
     effectOrCallback:

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,6 +169,25 @@ export interface TaskOperations {
   readonly getMetadata: (taskId: TaskId) => Effect.Effect<unknown>;
 }
 
+/** Task overloads shared by both entry points; Provided identifies requirements they supply. */
+export interface TaskApi<Provided> {
+  <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+    options: AddTaskOptions,
+  ): Effect.Effect<A, E, Exclude<R, Provided>>;
+  <A, E, R>(
+    options: AddTaskOptions,
+  ): (effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Provided>>;
+  <A, E, R>(
+    f: (handle: TaskHandle<void>) => Effect.Effect<A, E, R>,
+    options: AddTaskOptions<void>,
+  ): Effect.Effect<A, E, Exclude<R, Provided>>;
+  <M, A, E, R>(
+    f: (handle: TaskHandle<M>) => Effect.Effect<A, E, R>,
+    options: AddTaskOptions<M> & { readonly metadata: M },
+  ): Effect.Effect<A, E, Exclude<R, Provided>>;
+}
+
 export interface ProgressShape extends TaskOperations {
   readonly log: (...args: ReadonlyArray<unknown>) => Effect.Effect<void>;
   /**
@@ -180,23 +199,7 @@ export interface ProgressShape extends TaskOperations {
    *
    * Use `Progress.task(...)` from `src/api.ts` when you want the service to be created automatically if needed.
    */
-  readonly task: {
-    <A, E, R>(
-      effect: Effect.Effect<A, E, R>,
-      options: AddTaskOptions,
-    ): Effect.Effect<A, E, Exclude<R, Task>>;
-    <A, E, R>(
-      options: AddTaskOptions,
-    ): (effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Task>>;
-    <A, E, R>(
-      f: (handle: TaskHandle<void>) => Effect.Effect<A, E, R>,
-      options: AddTaskOptions<void>,
-    ): Effect.Effect<A, E, Exclude<R, Task>>;
-    <M, A, E, R>(
-      f: (handle: TaskHandle<M>) => Effect.Effect<A, E, R>,
-      options: AddTaskOptions<M> & { readonly metadata: M },
-    ): Effect.Effect<A, E, Exclude<R, Task>>;
-  };
+  readonly task: TaskApi<Task>;
 }
 
 export class Task extends Context.Service<Task, TaskId>()(

--- a/tests/task-api-types.test.ts
+++ b/tests/task-api-types.test.ts
@@ -1,0 +1,53 @@
+import { expectTypeOf, test } from "bun:test";
+import { Context, Effect, Result } from "effect";
+import * as Progress from "../src";
+
+class Dependency extends Context.Service<Dependency, { readonly value: number }>()(
+  "test/Dependency",
+) {}
+
+test("task overloads preserve values, errors, metadata and unrelated requirements", () => {
+  const work = Effect.gen(function* () {
+    yield* Progress.Progress;
+    yield* Progress.Task;
+    return (yield* Dependency).value;
+  });
+  expectTypeOf(Progress.task(work, { description: "public" })).toEqualTypeOf<
+    Effect.Effect<number, never, Dependency>
+  >();
+  expectTypeOf(
+    Progress.task(
+      (handle) => {
+        expectTypeOf(handle.getMetadata).toEqualTypeOf<Effect.Effect<{ score: number }>>();
+        return Effect.fail("failure" as const);
+      },
+      { description: "metadata", metadata: { score: 0 } },
+    ),
+  ).toEqualTypeOf<Effect.Effect<never, "failure", never>>();
+
+  const serviceWork = Effect.gen(function* () {
+    const progress = yield* Progress.Progress;
+    return yield* progress.task(work, { description: "service" });
+  });
+  expectTypeOf(serviceWork).toEqualTypeOf<
+    Effect.Effect<number, never, Progress.Progress | Dependency>
+  >();
+});
+
+test("all delegates tuple and record result inference to Effect", () => {
+  expectTypeOf(
+    Progress.all([Effect.succeed(1), Effect.succeed("two")], { description: "tuple" }),
+  ).toEqualTypeOf<Effect.Effect<[number, string]>>();
+  expectTypeOf(
+    Progress.all(
+      { value: Effect.fail("failure" as const) },
+      {
+        description: "record",
+        mode: "result",
+      },
+    ),
+  ).toEqualTypeOf<Effect.Effect<{ value: Result.Result<never, "failure"> }>>();
+  expectTypeOf(
+    Progress.all([Effect.succeed(1)], { description: "discard", discard: true }),
+  ).toEqualTypeOf<Effect.Effect<void>>();
+});


### PR DESCRIPTION
## Problem

The public task function and service task method duplicate the same four overloads, differing only in which environment requirements they provide. `AllReturn` separately reproduces Effect's tuple/object dispatch, even though Effect exposes the complete return-type utility.

## Solution

Define one `TaskApi<Provided>` overload contract. Use `TaskApi<Task>` for the service and `TaskApi<Progress | Task>` for the auto-provided API. Delegate collection result shape to `Effect.All.Return<Arg, O>`, then remove the Progress/Task requirements as before.

## Examples

```ts
// The public API supplies both Progress and Task:
Progress.task(work, { description: "Upload" });

// The service method supplies Task and retains other requirements:
progress.task(work, { description: "Upload" });
```

If `work` requires `Progress | Task | Dependency`, the public result requires only `Dependency`, and the service result retains `Progress | Dependency`.

`Progress.all([Effect.succeed(1), Effect.succeed("two")], options)` retains its `[number, string]` tuple. Record result mode retains the corresponding `Result` values, and discard mode returns void. Metadata callbacks retain their inferred metadata type.

## Validation

122 tests pass. Added compile-time assertions for public/service requirements, values, errors, metadata, tuple/record results, and discard mode. Typecheck, lint, formatter, Knip, and whitespace checks pass.
