### PR TITLE
Add anti-slop and compatible automation Oxlint rules

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,4 +1,4 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "ignorePatterns": [".agents/**"]
+  "ignorePatterns": [".agents/**", "tools/oxlint/anti-slop/**", "tools/oxlint/automation/**"]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -3,6 +3,82 @@
   "plugins": null,
   "categories": {},
   "rules": {
-    "require-yield": "allow"
-  }
+    "require-yield": "allow",
+    "anti-slop/no-chained-type-assertions": "error",
+    "anti-slop/no-conditional-empty-object-spread": "error",
+    "anti-slop/no-known-value-widening": "error",
+    "anti-slop/no-module-mocking": "error",
+    "anti-slop/no-object-parameters": "error",
+    "anti-slop/no-reflect-apply": "error",
+    "anti-slop/no-reflect-get": "error",
+    "anti-slop/no-runtime-typeof": "error",
+    "anti-slop/no-unsafe-dictionary-type": "error",
+    "anti-slop/no-shape-in-symbol-names": "error",
+    "anti-slop/no-unknown-parameters": "error",
+    "anti-slop/no-unknown-returns": "error",
+    "anti-slop/no-unknown-type-aliases": "error",
+    "anti-slop/no-widen-then-assert": "error",
+    "anti-slop/require-safety-comment-for-type-assertion": "error",
+    "anti-slop-effect/no-service-constructor-imports": "error",
+    "automation/no-banned-type-assertions": "error",
+    "automation/no-ambient-nondeterminism": "error",
+    "automation/no-cascading-layer-provide": "error",
+    "automation/no-direct-browser-storage": "error",
+    "automation/no-direct-fetch": "error",
+    "automation/no-disable-validation": "error",
+    "automation/no-effect-asvoid": "error",
+    "automation/no-global-json": "error",
+    "automation/no-in-operator": "error",
+    "automation/no-nested-effect-array-methods": "error",
+    "automation/no-nested-layer-provide": "error",
+    "automation/no-shadowed-standard-array-static": "error",
+    "automation/no-silent-error-swallow": "error",
+    "automation/no-static-effect-service-forwarders": "error",
+    "automation/no-switch": "error",
+    "automation/no-try-catch": "error",
+    "automation/no-typeof-object": "error",
+    "automation/pipe-max-arguments": "error",
+    "automation/prefer-effect-match": "error",
+    "automation/prefer-option-from-nullable": "error",
+    "automation/no-react-component-inner-functions": "error",
+    "automation/no-sql-type-parameter": "error"
+  },
+  "ignorePatterns": [".agents/**", "tools/oxlint/anti-slop/**", "tools/oxlint/automation/**"],
+  "jsPlugins": [
+    {
+      "name": "anti-slop",
+      "specifier": "./tools/oxlint/anti-slop/index.ts"
+    },
+    {
+      "name": "anti-slop-effect",
+      "specifier": "./tools/oxlint/anti-slop/effect/index.ts"
+    },
+    {
+      "name": "automation",
+      "specifier": "./tools/oxlint/automation/index.ts"
+    }
+  ],
+  "overrides": [
+    {
+      "files": [
+        "src/services/renderer/hooks/use-now-clock.ts",
+        "src/services/renderer/hooks/use-spinner-clock.ts"
+      ],
+      "rules": {
+        "automation/no-ambient-nondeterminism": [
+          "error",
+          {
+            "allowedDateBasenames": ["use-now-clock.ts", "use-spinner-clock.ts"],
+            "allowedDateExtensions": []
+          }
+        ]
+      }
+    },
+    {
+      "files": ["examples/benchmarks.ts"],
+      "rules": {
+        "automation/no-global-json": "off"
+      }
+    }
+  ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -12,12 +12,13 @@
       },
       "devDependencies": {
         "@effect/language-service": "^0.73.1",
+        "@oxlint/plugins": "1.78.0",
         "@types/bun": "latest",
         "@types/react": "^19.2.14",
         "effect": "^4.0.0-rc.112",
         "knip": "^5.86.0",
         "oxfmt": "^0.32.0",
-        "oxlint": "^1.47.0",
+        "oxlint": "1.78.0",
         "strip-ansi": "^7.2.0",
         "tsdown": "^0.21.0-beta.2",
         "typescript": "^5",
@@ -156,43 +157,45 @@
 
     "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-fF8VIOeligq+mA6KfKvWtFRXbf0EFy73TdR6ZnNejdJRM8VWN1e3QFhYgIwD7O8jBrQsd7EJbUpkAr/YlUOokg=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.47.0", "", { "os": "android", "cpu": "arm" }, "sha512-UHqo3te9K/fh29brCuQdHjN+kfpIi9cnTPABuD5S9wb9ykXYRGTOOMVuSV/CK43sOhU4wwb2nT1RVjcbrrQjFw=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.78.0", "", { "os": "android", "cpu": "arm" }, "sha512-Bu819lmAfZMUHErrpe0cEWj3iaefuUODHSU8+UbXy67V/r7/7f4K3FL0NmbD85E+wiFLDYuhP8Zlv0XnVeXshw=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.47.0", "", { "os": "android", "cpu": "arm64" }, "sha512-xh02lsTF1TAkR+SZrRMYHR/xCx8Wg2MAHxJNdHVpAKELh9/yE9h4LJeqAOBbIb3YYn8o/D97U9VmkvkfJfrHfw=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.78.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CDfxZgB61B7buRdY2FJoAYYPPXCZ1EoC1LKscnC5dg3kjobdxiconvAvvN1BmHyW4PyFT3jRLDag/BY/roSNBQ=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.47.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-OSOfNJqabOYbkyQDGT5pdoL+05qgyrmlQrvtCO58M4iKGEQ/xf3XkkKj7ws+hO+k8Y4VF4zGlBsJlwqy7qBcHA=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.78.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2Y2U9Ahrz+OO0Ej88f9SJYq51/jUBp1Mc7iZu0ukrbeeZ3gpRGfzIFnoqfHDY96xr0GEfNrPUBFEy0nN5aD7HA=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.47.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-hP2bOI4IWNS+F6pVXWtRshSTuJ1qCRZgDgVUg6EBUqsRy+ExkEPJkx+YmIuxgdCduYK1LKptLNFuQLJP8voPbQ=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.78.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rpych6eJq6m9jDRypTEaPD1xysaEW5h9+xuxhGK/QhOg+/xaqPZrCrTNoIl/f3nEjuJeCEmstNDlrE9rJi/3/g=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.47.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-F55jIEH5xmGu7S661Uho8vGiLFk0bY3A/g4J8CTKiLJnYu/PSMZ2WxFoy5Hji6qvFuujrrM9Q8XXbMO0fKOYPg=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.78.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-IcMGrQT3QizkOESUJd5et+rOhVqSkNDfNik1cvrKDqIbzqx9KMtRswpFgkCuNTSwylCFLKhGUu8KmqY1ZnC0Dg=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.47.0", "", { "os": "linux", "cpu": "arm" }, "sha512-wxmOn/wns/WKPXUC1fo5mu9pMZPVOu8hsynaVDrgmmXMdHKS7on6bA5cPauFFN9tJXNdsjW26AK9lpfu3IfHBQ=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.78.0", "", { "os": "linux", "cpu": "arm" }, "sha512-/uLdoJ0IXE6vo/0f0LKjinQAp+re+VMaCWaNT8ENIv2EOCkSsc8SGaflXAuW0Jua2dq5+GLVWm1NQK7P3UFSNQ=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.47.0", "", { "os": "linux", "cpu": "arm" }, "sha512-KJTmVIA/GqRlM2K+ZROH30VMdydEU7bDTY35fNg3tOPzQRIs2deLZlY/9JWwdWo1F/9mIYmpbdCmPqtKhWNOPg=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.78.0", "", { "os": "linux", "cpu": "arm" }, "sha512-7xi4Wb/O8NRJhLoUXmDJMUVpNYvB5kefdhFU1Jb8rtae4QoXlTiLwI14X4YvAXVZLNZChP8m5qO9SQAlWQTbkQ=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.47.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-PF7ELcFg1GVlS0X0ZB6aWiXobjLrAKer3T8YEkwIoO8RwWiAMkL3n3gbleg895BuZkHVlJ2kPRUwfrhHrVkD1A=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.78.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-4hFW0+fVXa3OIh1Y4A5SPkmvI4wuuBSrCVKzOyE7PTjhc7yEqZ1pmvEEeS5Lj/MaqvegFxXyF33N+6jkehxdyg=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.47.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-4BezLRO5cu0asf0Jp1gkrnn2OHiXrPPPEfBTxq1k5/yJ2zdGGTmZxHD2KF2voR23wb8Elyu3iQawXo7wvIZq0Q=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.78.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-oC0mvsgBJjlMijSDEhx9KuvR9zYeHXceA9MjbuXB1F8NSR78Yj2unOBrstEvTVaq+pko+kuue6DajC00eqvTdg=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.47.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-aI5ds9jq2CPDOvjeapiIj48T/vlWp+f4prkxs+FVzrmVN9BWIj0eqeJ/hV8WgXg79HVMIz9PU6deI2ki09bR1w=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.78.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-XAllT5SUZS+ohjuZ3/5S0cwe0r7eboiuigeStCZ5DXRYx/2KVM2UvQXvAfyzXEimtQjAB7cDQ2YxDe2Zl2WNQQ=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.47.0", "", { "os": "linux", "cpu": "none" }, "sha512-mO7ycp9Elvgt5EdGkQHCwJA6878xvo9tk+vlMfT1qg++UjvOMB8INsOCQIOH2IKErF/8/P21LULkdIrocMw9xA=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.78.0", "", { "os": "linux", "cpu": "none" }, "sha512-trucMER/0QtecoXvc1y/UVqE3kwJipDwrx4oHfj+nNm3dq2zjP44WT0CfHNDPM3G1DXIkx/gY6lAD21NSCZVhA=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.47.0", "", { "os": "linux", "cpu": "none" }, "sha512-24D0wsYT/7hDFn3Ow32m3/+QT/1ZwrUhShx4/wRDAmz11GQHOZ1k+/HBuK/MflebdnalmXWITcPEy4BWTi7TCA=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.78.0", "", { "os": "linux", "cpu": "none" }, "sha512-cm3O4F/HQbdzOUX5mKHqG5KDL6E5w0pnlZ+fbBy2rmLryPOowkuLagFHTopQsEIpjcaZoPOrL+BmmAytAG9HFg=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.47.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-8tPzPne882mtML/uy3mApvdCyuVOpthJ7xUv3b67gVfz63hOOM/bwO0cysSkPyYYFDFRn6/FnUb7Jhmsesntvg=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.78.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-33wRf6HqGNsybJ3qX4cGaQN2ODPxNmc1rMa0mrTmx3eFq1VzOnvQooi9bIGVYakW8a/wmqVx1mgsUm8R2xfTiw=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.47.0", "", { "os": "linux", "cpu": "x64" }, "sha512-q58pIyGIzeffEBhEgbRxLFHmHfV9m7g1RnkLiahQuEvyjKNiJcvdHOwKH2BdgZxdzc99Cs6hF5xTa86X40WzPw=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.78.0", "", { "os": "linux", "cpu": "x64" }, "sha512-rRdISSYegj6VganMZ9tjRjijowfHJ09IZU01i0toBAqr6n5LEtwHq2IeS4FjW2RoskOHlb6efB26H5izYb3GEQ=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.47.0", "", { "os": "linux", "cpu": "x64" }, "sha512-e7DiLZtETZUCwTa4EEHg9G+7g3pY+afCWXvSeMG7m0TQ29UHHxMARPaEQUE4mfKgSqIWnJaUk2iZzRPMRdga5g=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.78.0", "", { "os": "linux", "cpu": "x64" }, "sha512-GmsP4rW0xTL6u5CVdcDsaN5Fbc7hBc382Wmar1kttbnwSEviM+rSINKOMQ+UQ6iH+AGwC+8gaAiwu134Tgh6Lg=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.47.0", "", { "os": "none", "cpu": "arm64" }, "sha512-3AFPfQ0WKMleT/bKd7zsks3xoawtZA6E/wKf0DjwysH7wUiMMJkNKXOzYq1R/00G98JFgSU1AkrlOQrSdNNhlg=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.78.0", "", { "os": "none", "cpu": "arm64" }, "sha512-sy9yeYuADc8a+n4TLBayzMCZiHPW78DcIFVpOXTmdKHWQeM9xe5uzkqIIZmi326D5hY9XVwacipEB1p7tQjPAg=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.47.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-cLMVVM6TBxp+N7FldQJ2GQnkcLYEPGgiuEaXdvhgvSgODBk9ov3jed+khIXSAWtnFOW0wOnG3RjwqPh0rCuheA=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.78.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-rjc2hF1KfMi8fZj1X/m3AmnHbdsF3rL0v6KQg0Uc880Yb2khjz+3U14sfdZ7jWTpRnN1m1NQa/TT7uU9lJWPrA=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.47.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-VpFOSzvTnld77/Edje3ZdHgZWnlTb5nVWXyTgjD3/DKF/6t5bRRbwn3z77zOdnGy44xAMvbyAwDNOSeOdVUmRA=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.78.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zcuXFVrEFHIafRfkCQT8w/Xe41o07ozl/vwHq7p94vB29xVzsB0sZGYORU1jhcYKv3Lr0J3HbJ2T4fHH5rWmvA=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.47.0", "", { "os": "win32", "cpu": "x64" }, "sha512-+q8IWptxXx2HMTM6JluR67284t0h8X/oHJgqpxH1siowxPMqZeIpAcWCUq+tY+Rv2iQK8TUugjZnSBQAVV5CmA=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.78.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Sb5ocmLSuYeOuXd+CFOToGKp/gjXUEWDnvIGwhnh8aq8wY4TMmEnKnvbogSW7RdMZv77JSARduS7/gv+khYEjA=="],
+
+    "@oxlint/plugins": ["@oxlint/plugins@1.78.0", "", {}, "sha512-Ypt8KeRYw+4jUtlPirfcHWMrn5ms12VrrFPD+Mds477/7tJxG1Kcz2Yrg2nVcTQEUx/GdlhS+BUg1kmxNm04Ug=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
@@ -360,7 +363,7 @@
 
     "oxfmt": ["oxfmt@0.32.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.32.0", "@oxfmt/binding-android-arm64": "0.32.0", "@oxfmt/binding-darwin-arm64": "0.32.0", "@oxfmt/binding-darwin-x64": "0.32.0", "@oxfmt/binding-freebsd-x64": "0.32.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.32.0", "@oxfmt/binding-linux-arm-musleabihf": "0.32.0", "@oxfmt/binding-linux-arm64-gnu": "0.32.0", "@oxfmt/binding-linux-arm64-musl": "0.32.0", "@oxfmt/binding-linux-ppc64-gnu": "0.32.0", "@oxfmt/binding-linux-riscv64-gnu": "0.32.0", "@oxfmt/binding-linux-riscv64-musl": "0.32.0", "@oxfmt/binding-linux-s390x-gnu": "0.32.0", "@oxfmt/binding-linux-x64-gnu": "0.32.0", "@oxfmt/binding-linux-x64-musl": "0.32.0", "@oxfmt/binding-openharmony-arm64": "0.32.0", "@oxfmt/binding-win32-arm64-msvc": "0.32.0", "@oxfmt/binding-win32-ia32-msvc": "0.32.0", "@oxfmt/binding-win32-x64-msvc": "0.32.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-KArQhGzt/Y8M1eSAX98Y8DLtGYYDQhkR55THUPY5VNcpFQ+9nRZkL3ULXhagHMD2hIvjy8JSeEQEP5/yYJSrLA=="],
 
-    "oxlint": ["oxlint@1.47.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.47.0", "@oxlint/binding-android-arm64": "1.47.0", "@oxlint/binding-darwin-arm64": "1.47.0", "@oxlint/binding-darwin-x64": "1.47.0", "@oxlint/binding-freebsd-x64": "1.47.0", "@oxlint/binding-linux-arm-gnueabihf": "1.47.0", "@oxlint/binding-linux-arm-musleabihf": "1.47.0", "@oxlint/binding-linux-arm64-gnu": "1.47.0", "@oxlint/binding-linux-arm64-musl": "1.47.0", "@oxlint/binding-linux-ppc64-gnu": "1.47.0", "@oxlint/binding-linux-riscv64-gnu": "1.47.0", "@oxlint/binding-linux-riscv64-musl": "1.47.0", "@oxlint/binding-linux-s390x-gnu": "1.47.0", "@oxlint/binding-linux-x64-gnu": "1.47.0", "@oxlint/binding-linux-x64-musl": "1.47.0", "@oxlint/binding-openharmony-arm64": "1.47.0", "@oxlint/binding-win32-arm64-msvc": "1.47.0", "@oxlint/binding-win32-ia32-msvc": "1.47.0", "@oxlint/binding-win32-x64-msvc": "1.47.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.11.2" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-v7xkK1iv1qdvTxJGclM97QzN8hHs5816AneFAQ0NGji1BMUquhiDAhXpMwp8+ls16uRVJtzVHxP9pAAXblDeGA=="],
+    "oxlint": ["oxlint@1.78.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.78.0", "@oxlint/binding-android-arm64": "1.78.0", "@oxlint/binding-darwin-arm64": "1.78.0", "@oxlint/binding-darwin-x64": "1.78.0", "@oxlint/binding-freebsd-x64": "1.78.0", "@oxlint/binding-linux-arm-gnueabihf": "1.78.0", "@oxlint/binding-linux-arm-musleabihf": "1.78.0", "@oxlint/binding-linux-arm64-gnu": "1.78.0", "@oxlint/binding-linux-arm64-musl": "1.78.0", "@oxlint/binding-linux-ppc64-gnu": "1.78.0", "@oxlint/binding-linux-riscv64-gnu": "1.78.0", "@oxlint/binding-linux-riscv64-musl": "1.78.0", "@oxlint/binding-linux-s390x-gnu": "1.78.0", "@oxlint/binding-linux-x64-gnu": "1.78.0", "@oxlint/binding-linux-x64-musl": "1.78.0", "@oxlint/binding-openharmony-arm64": "1.78.0", "@oxlint/binding-win32-arm64-msvc": "1.78.0", "@oxlint/binding-win32-ia32-msvc": "1.78.0", "@oxlint/binding-win32-x64-msvc": "1.78.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-QgQePuxIqKOzo1KSjG2EnITEeWvWnKAm77eq8nrMtf6AGoA+zyGc4PFYtDNJSD25g/ibOwfQ851hZ4/SPkMVoA=="],
 
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 

--- a/examples/benchmarks.ts
+++ b/examples/benchmarks.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { Effect } from "effect";
 import { resolveColumns } from "../src/services/renderer/column-resolver";
 import { toRenderSnapshot } from "../src/services/store/render-snapshot";
-import { makeProgressStore } from "../src/services/store/store";
+import { ProgressStore } from "../src/services/store/store";
 import { TaskId, type TaskSnapshot, type ColumnDef, type TaskStore } from "../src/types";
 
 const WARMUP_ROUNDS = 3;
@@ -33,7 +33,7 @@ const summarize = ({ name, operations, samplesMillis }: Measurement) => {
 // Measure updates to one hot task while varying the size of the task Map copied by the store.
 const benchmarkStore = (taskCount: number) =>
   Effect.gen(function* () {
-    const store = yield* makeProgressStore;
+    const store = yield* ProgressStore;
     const taskIds: TaskId[] = [];
     for (let index = 0; index < taskCount; index++) {
       taskIds.push(yield* store.addTask({ description: `task-${index}` }));
@@ -64,7 +64,7 @@ const benchmarkStore = (taskCount: number) =>
     }
 
     return { name: `store: ${taskCount} tasks`, operations: STORE_UPDATES, samplesMillis };
-  }).pipe(Effect.scoped);
+  }).pipe(Effect.provide(ProgressStore.layer), Effect.scoped);
 
 const makeColumnFixture = (rowCount: number, distinctPrepare: boolean) => {
   const store = {

--- a/examples/helpers/performance-workload.ts
+++ b/examples/helpers/performance-workload.ts
@@ -4,7 +4,7 @@ import * as Progress from "../../src";
 type WorkloadSize = "short" | "long";
 
 /** Shared workload parameters keep standalone and comparison runs in sync. */
-export const makePerformanceWorkload = (size: WorkloadSize = "short") => {
+export const createPerformanceWorkload = (size: WorkloadSize = "short") => {
   const prefix = size === "long" ? "Long performance" : "Performance";
   const WORKERS = 16;
   const BATCHES_PER_WORKER = 8;
@@ -102,7 +102,7 @@ export const makePerformanceWorkload = (size: WorkloadSize = "short") => {
 };
 
 export const runPerformanceComparison = async (size: WorkloadSize = "short"): Promise<void> => {
-  const { bareProgram, progressRun } = makePerformanceWorkload(size);
+  const { bareProgram, progressRun } = createPerformanceWorkload(size);
   console.log("Running bare (no Progress)...\n");
   const bareStart = performance.now();
   await Effect.runPromise(bareProgram);

--- a/examples/nesting.ts
+++ b/examples/nesting.ts
@@ -3,11 +3,9 @@ import * as Progress from "../src";
 
 const program = Progress.all(
   Array.from({ length: 5 }).map((_, i) =>
-    Effect.asVoid(
-      Progress.all(
-        Array.from({ length: 15 }).map((_) => Effect.sleep("100 millis")),
-        { description: `Running subtasks for task ${i + 1}` },
-      ),
+    Progress.all(
+      Array.from({ length: 15 }).map((_) => Effect.sleep("100 millis")),
+      { description: `Running subtasks for task ${i + 1}`, discard: true },
     ),
   ),
   { description: "Running tasks in parallel", concurrency: 2, transient: false },

--- a/examples/performance.ts
+++ b/examples/performance.ts
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import { makePerformanceWorkload } from "./helpers/performance-workload";
+import { createPerformanceWorkload } from "./helpers/performance-workload";
 
-const { progressRun } = makePerformanceWorkload("short");
+const { progressRun } = createPerformanceWorkload("short");
 await Effect.runPromise(progressRun);

--- a/examples/performanceLong.ts
+++ b/examples/performanceLong.ts
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import { makePerformanceWorkload } from "./helpers/performance-workload";
+import { createPerformanceWorkload } from "./helpers/performance-workload";
 
-const { progressRun } = makePerformanceWorkload("long");
+const { progressRun } = createPerformanceWorkload("long");
 await Effect.runPromise(progressRun);

--- a/examples/showcase.ts
+++ b/examples/showcase.ts
@@ -1,11 +1,10 @@
-import { Effect, Logger } from "effect";
+import { Effect, Logger, Random } from "effect";
 import * as Progress from "../src";
 
-const randomMillis = (base: number, jitter: number) =>
-  Math.max(80, Math.round(base + (Math.random() * 2 - 1) * jitter));
-
 const sleepRandom = (base: number, jitter: number) =>
-  Effect.sleep(`${randomMillis(base, jitter)} millis`);
+  Effect.flatMap(Random.nextBetween(-jitter, jitter), (offset) =>
+    Effect.sleep(`${Math.max(80, Math.round(base + offset))} millis`),
+  );
 
 const stages = ["fetch", "transform", "persist"] as const;
 const services = ["identity", "catalog"] as const;

--- a/examples/typedMetadata.ts
+++ b/examples/typedMetadata.ts
@@ -1,11 +1,10 @@
-import { Data, Effect, Logger } from "effect";
+import { Data, Effect, Logger, Random } from "effect";
 import * as Progress from "../src";
 
-const randomMillis = (base: number, jitter: number) =>
-  Math.max(80, Math.round(base + (Math.random() * 2 - 1) * jitter));
-
 const sleepRandom = (base: number, jitter: number) =>
-  Effect.sleep(`${randomMillis(base, jitter)} millis`);
+  Effect.flatMap(Random.nextBetween(-jitter, jitter), (offset) =>
+    Effect.sleep(`${Math.max(80, Math.round(base + offset))} millis`),
+  );
 
 // --- Typed metadata example ---
 // Each model evaluation task carries structured metadata that gets
@@ -21,8 +20,8 @@ class EvalError extends Data.TaggedError("EvalError")<{
 const runEval = (model: string, script: string) =>
   Effect.gen(function* () {
     yield* sleepRandom(1200, 400);
-    const score = Math.round(Math.random() * 40 + 60);
-    const passed = Math.random() > 0.15;
+    const score = Math.round(yield* Random.nextBetween(60, 100));
+    const passed = (yield* Random.next) > 0.15;
     if (!passed) {
       return yield* new EvalError({ message: `${model}/${script} failed` });
     }

--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "entry": ["examples/**/*.ts", "tests/**/*.ts", "tests/**/*.tsx"],
+  "entry": [
+    "examples/**/*.ts",
+    "tests/**/*.ts",
+    "tests/**/*.tsx",
+    "tools/oxlint/anti-slop/index.ts",
+    "tools/oxlint/anti-slop/effect/index.ts",
+    "tools/oxlint/automation/index.ts"
+  ],
   "project": ["src/**/*.ts", "src/**/*.tsx", "examples/**/*.ts", "tests/**/*.ts", "tests/**/*.tsx"]
 }

--- a/package.json
+++ b/package.json
@@ -51,12 +51,13 @@
   },
   "devDependencies": {
     "@effect/language-service": "^0.73.1",
+    "@oxlint/plugins": "1.78.0",
     "@types/bun": "latest",
     "@types/react": "^19.2.14",
     "effect": "^4.0.0-rc.112",
     "knip": "^5.86.0",
     "oxfmt": "^0.32.0",
-    "oxlint": "^1.47.0",
+    "oxlint": "1.78.0",
     "strip-ansi": "^7.2.0",
     "tsdown": "^0.21.0-beta.2",
     "typescript": "^5"

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,7 +5,7 @@ import { Progress } from "./services/progress";
 import { Task } from "./types";
 import type {
   AddTaskOptions,
-  ProgressShape,
+  ProgressService,
   TaskCountDisplay,
   TaskApi,
   TaskHandle,
@@ -66,10 +66,13 @@ export const task: TaskApi<Progress | Task> = dual(
       | ((handle: TaskHandle<any>) => Effect.Effect<A, E, R>),
     options: TaskOptions<any>,
   ) => {
+    // SAFETY: provideProgress supplies Progress and progress.task supplies Task for both overloads.
     return provideProgress(
       Effect.gen(function* () {
         const progress = yield* Progress;
-        return yield* progress.task(effectOrCallback as any, options);
+        return yield* Effect.isEffect(effectOrCallback)
+          ? progress.task(effectOrCallback, options)
+          : progress.task(effectOrCallback, options);
       }),
     ) as Effect.Effect<A, E, Exclude<R, Progress | Task>>;
   },
@@ -96,7 +99,7 @@ const allCountDisplay = (mode: EffectAllExecutionOptions["mode"]): TaskCountDisp
   isCollectAllMode(mode) ? "detailed" : "processedOnly";
 
 const wrapTrackedEffect = <A, E, R>(
-  progress: ProgressShape,
+  progress: ProgressService,
   taskId: TaskId,
   effect: Effect.Effect<A, E, R>,
 ) =>
@@ -107,7 +110,7 @@ const wrapTrackedEffect = <A, E, R>(
     return Cause.hasInterruptsOnly(exit.cause) ? Effect.void : progress.incrementFailed(taskId);
   });
 
-const isTaskFullyProcessed = (progress: ProgressShape, taskId: TaskId) =>
+const isTaskFullyProcessed = (progress: ProgressService, taskId: TaskId) =>
   Effect.gen(function* () {
     const taskOption = yield* progress.getTask(taskId);
     if (Option.isNone(taskOption)) {
@@ -136,6 +139,7 @@ export const all: {
     effects: Arg,
     options: Omit<TrackOptions, "total" | "countDisplay"> & O,
   ) =>
+    // SAFETY: Wrapping preserves Effect.all keys, values, errors and mode; task supplies Progress and Task.
     provideProgress(
       Effect.gen(function* () {
         const progress = yield* Progress;

--- a/src/columns.tsx
+++ b/src/columns.tsx
@@ -1,3 +1,4 @@
+import { Predicate } from "effect";
 import type { ColumnDef, ColumnSizeValue } from "./types";
 import {
   AmountCell,
@@ -34,7 +35,7 @@ const resolveBarSize = (size: number | "fullwidth" | undefined): number | "fullw
     return size;
   }
 
-  if (typeof size !== "number" || !Number.isFinite(size)) {
+  if (size === undefined || !Number.isFinite(size)) {
     return DEFAULT_BAR_SIZE;
   }
 
@@ -125,7 +126,7 @@ export const resolveColumnSizeValue = <P,>(
   value: ColumnSizeValue<P> | undefined,
   prepared: P,
 ): number | undefined => {
-  if (typeof value === "function") {
+  if (Predicate.isFunction(value)) {
     return value(prepared);
   }
 

--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -1,7 +1,7 @@
 import { Context, Effect, Exit, Layer, Option } from "effect";
 import { dual } from "effect/Function";
 import { ProgressStore } from "./store/store";
-import type { AddTaskOptions, ProgressShape, TaskHandle, TaskId } from "../types";
+import type { AddTaskOptions, ProgressService, TaskHandle, TaskId } from "../types";
 import { Task } from "../types";
 import { Renderer } from "./renderer/renderer";
 import { ProgressStdio } from "./stdio";
@@ -42,10 +42,12 @@ const makeProgressService = Effect.gen(function* () {
 
   const makeTaskHandle = <M>(taskId: TaskId): TaskHandle<M> => ({
     id: taskId,
+    // SAFETY: This handle belongs to the task created with metadata M; handle writes preserve M.
     getMetadata: store.getMetadata(taskId) as Effect.Effect<M>,
     setMetadata: (metadata) => store.setMetadata(taskId, metadata),
     updateMetadata: (f) =>
       Effect.flatMap(store.getMetadata(taskId), (current) =>
+        // SAFETY: The task handle reads the same metadata M established at task creation.
         store.setMetadata(taskId, f(current as M)),
       ),
     incrementSucceeded: (amount) => store.incrementSucceeded(taskId, amount),
@@ -67,7 +69,7 @@ const makeProgressService = Effect.gen(function* () {
       );
     });
 
-  const task: ProgressShape["task"] = dual(
+  const task: ProgressService["task"] = dual(
     2,
     <A, E, R>(
       effectOrCallback:
@@ -80,9 +82,9 @@ const makeProgressService = Effect.gen(function* () {
           const taskId = yield* Task;
           return yield* Effect.onExit(
             Effect.suspend(() =>
-              typeof effectOrCallback === "function"
-                ? effectOrCallback(makeTaskHandle(taskId))
-                : effectOrCallback,
+              Effect.isEffect(effectOrCallback)
+                ? effectOrCallback
+                : effectOrCallback(makeTaskHandle(taskId)),
             ),
             // Store finalization is terminal, so explicit completion/failure always wins.
             (exit) => (Exit.isSuccess(exit) ? store.completeTask(taskId) : store.failTask(taskId)),
@@ -104,7 +106,7 @@ const makeProgressService = Effect.gen(function* () {
     setMetadata: store.setMetadata,
     getMetadata: store.getMetadata,
     task,
-  } satisfies ProgressShape;
+  } satisfies ProgressService;
 
   return Progress.of(service);
 });
@@ -131,14 +133,16 @@ const CurrentParent = Context.Reference<Option.Option<CurrentParentState>>(
   { defaultValue: Option.none },
 );
 
-export class Progress extends Context.Service<Progress, ProgressShape>()(
+export class Progress extends Context.Service<Progress, ProgressService>()(
   "stromseng.dev/effective-progress/Progress",
 ) {
   static readonly layer = Layer.effect(Progress, makeProgressService).pipe(
     Layer.provide(
       serviceOptionDefaultLayer(Renderer, Renderer.layer).pipe(
-        Layer.provideMerge(serviceOptionDefaultLayer(ProgressStdio, ProgressStdio.layer)),
-        Layer.provideMerge(ProgressStore.layer),
+        Layer.provideMerge([
+          serviceOptionDefaultLayer(ProgressStdio, ProgressStdio.layer),
+          ProgressStore.layer,
+        ]),
       ),
     ),
   );

--- a/src/services/renderer/hooks/use-progress-render-view.ts
+++ b/src/services/renderer/hooks/use-progress-render-view.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
-import type { ProgressStoreShape } from "../../store/store";
+import type { ProgressStoreService } from "../../store/store";
 import type { TaskStore } from "../../../types";
 import { toRenderSnapshot, type RenderSnapshot } from "../../store/render-snapshot";
 
@@ -24,7 +24,7 @@ const useRenderSnapshot = (storeSnapshot: TaskStore): RenderSnapshot => {
   return renderSnapshot;
 };
 
-export const useProgressRenderView = (store: ProgressStoreShape): ProgressRenderView => {
+export const useProgressRenderView = (store: ProgressStoreService): ProgressRenderView => {
   const storeSnapshot = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
   const renderSnapshot = useRenderSnapshot(storeSnapshot);
 

--- a/src/services/renderer/public-api.tsx
+++ b/src/services/renderer/public-api.tsx
@@ -1,3 +1,4 @@
+import { Predicate } from "effect";
 import { Box, Text, useBoxMetrics, type DOMElement } from "ink";
 import type { ReactElement, ReactNode } from "react";
 import { useRef } from "react";
@@ -23,7 +24,7 @@ const justifyContentForAlign = (align: ColumnAlign | undefined) => {
 };
 
 const RenderedNode = ({ node }: { readonly node: ReactNode }) => {
-  if (typeof node === "string" || typeof node === "number") {
+  if (Predicate.isString(node) || Predicate.isNumber(node)) {
     return <Text wrap="truncate-end">{node}</Text>;
   }
 

--- a/src/services/renderer/renderer.tsx
+++ b/src/services/renderer/renderer.tsx
@@ -3,17 +3,17 @@ import { render } from "ink";
 import { NowProvider } from "./context/now-context";
 import { SpinnerProvider } from "./context/spinner-context";
 import { ProgressRenderer } from "./public-api";
-import { ProgressStore, type ProgressStoreShape } from "../store/store";
+import { ProgressStore, type ProgressStoreService } from "../store/store";
 import { useProgressRenderView } from "./hooks/use-progress-render-view";
 import { ProgressStdio } from "../stdio";
 
-interface RendererShape {
+interface RendererService {
   readonly run: Effect.Effect<void>;
 }
 
 const MAX_FPS = 24;
 
-const ProgressRoot = ({ store }: { readonly store: ProgressStoreShape }) => {
+const ProgressRoot = ({ store }: { readonly store: ProgressStoreService }) => {
   const { renderSnapshot, hasRunningTasks, storeSnapshot } = useProgressRenderView(store);
 
   return (
@@ -55,10 +55,10 @@ const makeRendererService = Effect.gen(function* () {
         ),
       ),
     ),
-  } satisfies RendererShape;
+  } satisfies RendererService;
 });
 
-export class Renderer extends Context.Service<Renderer, RendererShape>()(
+export class Renderer extends Context.Service<Renderer, RendererService>()(
   "stromseng.dev/effective-progress/Renderer",
 ) {
   static readonly layer = Layer.effect(Renderer, makeRendererService);

--- a/src/services/stdio.ts
+++ b/src/services/stdio.ts
@@ -1,16 +1,16 @@
 import { Context, Layer } from "effect";
 
-export interface ProgressStdioShape {
+export interface ProgressStdioService {
   readonly stdout: NodeJS.WriteStream;
   readonly stderr: NodeJS.WriteStream;
 }
 
-const defaultStdioService: ProgressStdioShape = {
+const defaultStdioService: ProgressStdioService = {
   stdout: process.stdout,
   stderr: process.stderr,
 };
 
-export class ProgressStdio extends Context.Service<ProgressStdio, ProgressStdioShape>()(
+export class ProgressStdio extends Context.Service<ProgressStdio, ProgressStdioService>()(
   "stromseng.dev/effective-progress/ProgressStdio",
 ) {
   static readonly layer = Layer.succeed(ProgressStdio, defaultStdioService);

--- a/src/services/store/store.ts
+++ b/src/services/store/store.ts
@@ -19,7 +19,7 @@ interface TaskCounts {
 const ETA_SAMPLE_WINDOW_MILLIS = 30_000;
 const ETA_SAMPLE_MAX_LENGTH = 1_000;
 
-export interface ProgressStoreShape extends TaskOperations {
+export interface ProgressStoreService extends TaskOperations {
   readonly getSnapshot: () => TaskStore;
   readonly subscribe: (listener: () => void) => () => void;
   readonly flush: () => void;
@@ -193,7 +193,7 @@ const removeTransientSubtree = (
 const SNAPSHOT_PUBLISH_INTERVAL_MILLIS = 100;
 
 interface ProgressStoreRuntime {
-  readonly store: ProgressStoreShape;
+  readonly store: ProgressStoreService;
   readonly publisherLoop: Effect.Effect<never>;
 }
 
@@ -335,7 +335,7 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
       }, now);
     });
 
-  const store: ProgressStoreShape = {
+  const store: ProgressStoreService = {
     getSnapshot: () => publishedSnapshot,
     subscribe: (listener) => {
       listeners.add(listener);
@@ -384,10 +384,7 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
           nextRenderOrder.splice(index, 0, { id: taskId, depth });
 
           const nextColumns = options.columns
-            ? new Map(current.columns).set(
-                taskId,
-                options.columns as ReadonlyArray<ColumnDef<any, any>>,
-              )
+            ? new Map(current.columns).set(taskId, options.columns)
             : current.columns;
 
           return { tasks: nextTasks, renderOrder: nextRenderOrder, columns: nextColumns };
@@ -451,7 +448,7 @@ export const makeProgressStore = Effect.gen(function* () {
   return runtime.store;
 });
 
-export class ProgressStore extends Context.Service<ProgressStore, ProgressStoreShape>()(
+export class ProgressStore extends Context.Service<ProgressStore, ProgressStoreService>()(
   "stromseng.dev/effective-progress/ProgressStore",
 ) {
   static readonly layer = Layer.effect(ProgressStore, makeProgressStore);

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,7 +163,7 @@ export interface TaskOperations {
   readonly failTask: (taskId: TaskId) => Effect.Effect<void>;
   readonly getTask: (taskId: TaskId) => Effect.Effect<Option.Option<TaskSnapshot>>;
   readonly listTasks: Effect.Effect<ReadonlyArray<TaskSnapshot>>;
-  readonly setMetadata: (taskId: TaskId, metadata: unknown) => Effect.Effect<void>;
+  readonly setMetadata: <M>(taskId: TaskId, metadata: M) => Effect.Effect<void>;
   readonly getMetadata: (taskId: TaskId) => Effect.Effect<unknown>;
 }
 
@@ -186,7 +186,7 @@ export interface TaskApi<Provided> {
   ): Effect.Effect<A, E, Exclude<R, Provided>>;
 }
 
-export interface ProgressShape extends TaskOperations {
+export interface ProgressService extends TaskOperations {
   /**
    * Runs an effect inside a newly created task scope.
    *

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,20 +1,21 @@
+import { Predicate } from "effect";
+
 export const inferTotal = (iterable: Iterable<unknown>): number | undefined => {
   if (Array.isArray(iterable)) {
     return iterable.length;
   }
 
-  if (typeof iterable === "string") {
+  if (Predicate.isString(iterable)) {
     // String iteration yields Unicode code points, not UTF-16 code units.
     return [...iterable].length;
   }
 
-  const candidate = iterable as { length?: unknown; size?: unknown };
-  if (typeof candidate.length === "number") {
-    return candidate.length;
+  if (Predicate.hasProperty(iterable, "length") && Predicate.isNumber(iterable.length)) {
+    return iterable.length;
   }
 
-  if (typeof candidate.size === "number") {
-    return candidate.size;
+  if (Predicate.hasProperty(iterable, "size") && Predicate.isNumber(iterable.size)) {
+    return iterable.size;
   }
 
   return undefined;

--- a/tests/helpers/mock-stdio.ts
+++ b/tests/helpers/mock-stdio.ts
@@ -1,5 +1,5 @@
-import { PassThrough } from "node:stream";
-import type { ProgressStdioShape } from "../../src/services/stdio";
+import { PassThrough, type Writable } from "node:stream";
+import type { ProgressStdioService } from "../../src/services/stdio";
 
 interface MockWriteStreamOptions {
   readonly isTTY: boolean;
@@ -19,7 +19,7 @@ interface MockStdioOptions {
 }
 
 export interface MockStdioHandle {
-  readonly service: ProgressStdioShape;
+  readonly service: ProgressStdioService;
   readonly stdout: MockWriteStreamHandle;
   readonly stderr: MockWriteStreamHandle;
 }
@@ -31,23 +31,20 @@ const createMockWriteStream = (options: MockWriteStreamOptions): MockWriteStream
   const rows = options.rows ?? 0;
 
   stream.setEncoding("utf8");
-  stream.on("data", (chunk) => {
-    output += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+  stream.on("data", (chunk: string) => {
+    output += chunk;
   });
 
-  const writeStream = stream as unknown as NodeJS.WriteStream & {
-    isTTY?: boolean;
-    columns?: number;
-    rows?: number;
-    getWindowSize?: () => [number, number];
-  };
-  writeStream.isTTY = options.isTTY;
-  writeStream.columns = columns;
-  writeStream.rows = rows;
-  writeStream.getWindowSize = () => [columns, rows];
+  const writeStream: Writable = Object.assign(stream, {
+    isTTY: options.isTTY,
+    columns,
+    rows,
+    getWindowSize: (): [number, number] => [columns, rows],
+  });
 
   return {
-    stream: writeStream,
+    // SAFETY: The Writable has the TTY fields assigned above; Ink only uses that surface.
+    stream: writeStream as NodeJS.WriteStream,
     getOutput: () => output,
     clear: () => {
       output = "";

--- a/tests/ink-renderer.test.ts
+++ b/tests/ink-renderer.test.ts
@@ -4,8 +4,8 @@ import stripAnsi from "strip-ansi";
 import * as Progress from "../src";
 import { createMockStdio } from "./helpers/mock-stdio";
 
-const captureStdioOutput = async <A, E, R>(
-  effect: Effect.Effect<A, E, R>,
+const captureStdioOutput = async <A, E>(
+  effect: Effect.Effect<A, E, Progress.ProgressStdio>,
   options: {
     readonly isTTY: boolean;
     readonly columns?: number;
@@ -17,11 +17,7 @@ const captureStdioOutput = async <A, E, R>(
   });
 
   const result = await Effect.runPromise(
-    effect.pipe(Effect.provideService(Progress.ProgressStdio, stdio.service)) as Effect.Effect<
-      A,
-      E,
-      never
-    >,
+    effect.pipe(Effect.provideService(Progress.ProgressStdio, stdio.service)),
   );
 
   return {

--- a/tests/renderer-public-api.test.tsx
+++ b/tests/renderer-public-api.test.tsx
@@ -4,10 +4,10 @@ import { makeTaskSnapshot, makeRow as deriveRow, renderRows } from "./helpers/re
 import { resolveColumns } from "../src/services/renderer/column-resolver";
 import type { TaskRowModel } from "../src/services/store/types";
 
-const makeTask = (
+const makeTask = <M,>(
   id: number,
   description: string,
-  metadata?: unknown,
+  metadata?: M,
   overrides: Partial<Progress.TaskSnapshot> = {},
 ): Progress.TaskSnapshot =>
   makeTaskSnapshot({ id: Progress.TaskId(id), description, metadata, ...overrides });

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -16,7 +16,7 @@ const getTaskOrFail = (
   label: string,
 ): Progress.TaskSnapshot => {
   expect(Option.isSome(task), `Expected task "${label}" to exist`).toBeTrue();
-  return (task as Option.Some<Progress.TaskSnapshot>).value;
+  return Option.getOrThrow(task);
 };
 
 describe("transient propagation", () => {

--- a/tests/task-scopes.test.ts
+++ b/tests/task-scopes.test.ts
@@ -246,7 +246,7 @@ describe("Progress task scopes", () => {
 
     expect(result).toEqual([undefined, undefined]);
     expect(
-      logs.some((args) => typeof args[0] === "string" && args[0].startsWith(capturedPrefix)),
+      logs.some((args) => args[0] === `${capturedPrefix}:a` || args[0] === `${capturedPrefix}:b`),
     ).toBeTrue();
   });
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -13,4 +13,22 @@ describe("inferTotal", () => {
   ] as const)("counts string iteration items for %j", (input, expected) => {
     expect(inferTotal(input)).toBe(expected);
   });
+  test("reads collection lengths and sizes without consuming the iterable", () => {
+    expect(inferTotal([1, 2])).toBe(2);
+    expect(inferTotal(new Set([1, 2]))).toBe(2);
+    expect(inferTotal(new Map([[1, "one"]]))).toBe(1);
+
+    const iterable = {
+      length: "untrusted length",
+      size: 2,
+      *[Symbol.iterator]() {
+        throw new Error("Total inference must not consume custom iterables");
+      },
+    };
+    expect(inferTotal(iterable)).toBe(2);
+    const invalidSize = { ...iterable, size: "untrusted size" };
+    const withLength = { ...iterable, length: 3 };
+    expect(inferTotal(invalidSize)).toBeUndefined();
+    expect(inferTotal(withLength)).toBe(3);
+  });
 });

--- a/tools/oxlint/anti-slop/LICENSE
+++ b/tools/oxlint/anti-slop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dillon Mulroy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/oxlint/anti-slop/README.md
+++ b/tools/oxlint/anti-slop/README.md
@@ -1,0 +1,13 @@
+# Anti-slop Oxlint rules
+
+Vendored from https://github.com/dmmulroy/anti-slop at commit `e8c4880471b23ab7f216fba7b27d173a6ef07d4c` (MIT).
+Only runtime rule sources are copied; no agent skill is installed.
+
+Both plugin entry points are registered in `.oxlintrc.json`. Keep `oxlint` and
+`@oxlint/plugins` pinned to the same version when upgrading.
+
+To update, copy upstream `src/` here excluding `*.test.ts`, preserve the license,
+and update the commit above. Run `bun run check` and `bun test` after updating.
+
+Local adaptation: `shared/dictionary-types.ts` coalesces the first intersection
+member to `null` for this project’s `noUncheckedIndexedAccess` setting.

--- a/tools/oxlint/anti-slop/effect/index.ts
+++ b/tools/oxlint/anti-slop/effect/index.ts
@@ -1,0 +1,13 @@
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { noServiceConstructorImportsRule } from "./rules/no-service-constructor-imports.ts";
+
+/** Opt-in Oxlint rules for Effect service and Layer architecture. */
+const antiSlopEffectPlugin = eslintCompatPlugin({
+	meta: { name: "anti-slop-effect" },
+	rules: {
+		"no-service-constructor-imports": noServiceConstructorImportsRule,
+	},
+});
+
+export default antiSlopEffectPlugin;

--- a/tools/oxlint/anti-slop/effect/rules/no-service-constructor-imports.ts
+++ b/tools/oxlint/anti-slop/effect/rules/no-service-constructor-imports.ts
@@ -1,0 +1,52 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+const SERVICE_CONSTRUCTOR_NAME = /^make[A-Z]/u;
+const TEST_FILE = /\.(?:test|spec)\.[cm]?[jt]sx?$/u;
+
+function isProjectLocalImport(source: string): boolean {
+	return source.startsWith("./") || source.startsWith("../");
+}
+
+function getImportedName(specifier: ESTree.ImportSpecifier): string {
+	if (specifier.imported.type === "Identifier") return specifier.imported.name;
+	return specifier.imported.value;
+}
+
+/** Keep dependency-bearing Effect service constructors local to their owning capability modules. */
+export const noServiceConstructorImportsRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow project-local make<CapabilityName> imports outside test and spec files.",
+		},
+		messages: {
+			serviceConstructorImport:
+				'Do not import Effect service constructor "{{name}}" into runtime code. Import the owning Layer, yield the contextual service, and allow its requirements to propagate to the composition root.',
+		},
+	},
+	create(context) {
+		const isTestFile = TEST_FILE.test(context.filename.replaceAll("\\", "/"));
+
+		return {
+			ImportDeclaration(node) {
+				if (isTestFile || !isProjectLocalImport(node.source.value)) return;
+
+				for (const specifier of node.specifiers) {
+					if (specifier.type !== "ImportSpecifier") continue;
+
+					const importedName = getImportedName(specifier);
+					if (!SERVICE_CONSTRUCTOR_NAME.test(importedName)) continue;
+
+					context.report({
+						node: specifier,
+						messageId: "serviceConstructorImport",
+						data: { name: importedName },
+					});
+				}
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/index.ts
+++ b/tools/oxlint/anti-slop/index.ts
@@ -1,0 +1,41 @@
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { noChainedTypeAssertionsRule } from "./rules/no-chained-type-assertions.ts";
+import { noConditionalEmptyObjectSpreadRule } from "./rules/no-conditional-empty-object-spread.ts";
+import { noKnownValueWideningRule } from "./rules/no-known-value-widening.ts";
+import { noModuleMockingRule } from "./rules/no-module-mocking.ts";
+import { noObjectParametersRule } from "./rules/no-object-parameters.ts";
+import { noReflectApplyRule } from "./rules/no-reflect-apply.ts";
+import { noReflectGetRule } from "./rules/no-reflect-get.ts";
+import { noRuntimeTypeofRule } from "./rules/no-runtime-typeof.ts";
+import { noForbiddenTermInSymbolNamesRule } from "./rules/no-shape-in-symbol-names.ts";
+import { noUnknownParametersRule } from "./rules/no-unknown-parameters.ts";
+import { noUnknownReturnsRule } from "./rules/no-unknown-returns.ts";
+import { noUnknownTypeAliasesRule } from "./rules/no-unknown-type-aliases.ts";
+import { noUnsafeDictionaryTypeRule } from "./rules/no-unsafe-dictionary-type.ts";
+import { noWidenThenAssertRule } from "./rules/no-widen-then-assert.ts";
+import { requireSafetyCommentForTypeAssertionRule } from "./rules/require-safety-comment-for-type-assertion.ts";
+
+/** Generic Oxlint rules that reject low-evidence and low-signal implementation patterns. */
+const antiSlopPlugin = eslintCompatPlugin({
+	meta: { name: "anti-slop" },
+	rules: {
+		"no-chained-type-assertions": noChainedTypeAssertionsRule,
+		"no-conditional-empty-object-spread": noConditionalEmptyObjectSpreadRule,
+		"no-known-value-widening": noKnownValueWideningRule,
+		"no-module-mocking": noModuleMockingRule,
+		"no-object-parameters": noObjectParametersRule,
+		"no-reflect-apply": noReflectApplyRule,
+		"no-reflect-get": noReflectGetRule,
+		"no-runtime-typeof": noRuntimeTypeofRule,
+		"no-unsafe-dictionary-type": noUnsafeDictionaryTypeRule,
+		"no-shape-in-symbol-names": noForbiddenTermInSymbolNamesRule,
+		"no-unknown-parameters": noUnknownParametersRule,
+		"no-unknown-returns": noUnknownReturnsRule,
+		"no-unknown-type-aliases": noUnknownTypeAliasesRule,
+		"no-widen-then-assert": noWidenThenAssertRule,
+		"require-safety-comment-for-type-assertion": requireSafetyCommentForTypeAssertionRule,
+	},
+});
+
+export default antiSlopPlugin;

--- a/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
+++ b/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
@@ -1,0 +1,77 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+type TypeAssertionExpression = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+function isTypeAssertionExpression(node: ESTree.Node): node is TypeAssertionExpression {
+  return node.type === "TSAsExpression" || node.type === "TSTypeAssertion";
+}
+
+function unwrapParenthesizedExpression(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isConstAssertion(node: TypeAssertionExpression): boolean {
+  const { typeAnnotation } = node;
+  return (
+    typeAnnotation.type === "TSTypeReference" &&
+    typeAnnotation.typeName.type === "Identifier" &&
+    typeAnnotation.typeName.name === "const"
+  );
+}
+
+function isOutermostAssertionInChain(node: TypeAssertionExpression): boolean {
+  let current: ESTree.Expression = node;
+  let parent = node.parent;
+
+  while (parent.type === "ParenthesizedExpression" && parent.expression === current) {
+    current = parent;
+    parent = parent.parent;
+  }
+
+  return !isTypeAssertionExpression(parent) || parent.expression !== current;
+}
+
+function isForbiddenAssertionChain(node: TypeAssertionExpression): boolean {
+  let assertionCount = 0;
+  let hasNonConstAssertion = false;
+  let current: ESTree.Expression = node;
+
+  while (isTypeAssertionExpression(current)) {
+    assertionCount += 1;
+    hasNonConstAssertion ||= !isConstAssertion(current);
+    current = unwrapParenthesizedExpression(current.expression);
+  }
+
+  return assertionCount > 1 && hasNonConstAssertion;
+}
+
+/** Disallow nested TypeScript type assertions, while permitting chains made only of const assertions. */
+export const noChainedTypeAssertionsRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow chained TypeScript as and angle-bracket assertions, including parenthesized chains.",
+    },
+    messages: {
+      chained:
+        "This assertion chain discards type evidence. Keep the original precise type, or parse untrusted input at its boundary before narrowing it.",
+    },
+  },
+  createOnce(context) {
+    const checkTypeAssertion = (node: TypeAssertionExpression) => {
+      if (!isOutermostAssertionInChain(node) || !isForbiddenAssertionChain(node)) return;
+      context.report({ node, messageId: "chained" });
+    };
+
+    return {
+      TSAsExpression: checkTypeAssertion,
+      TSTypeAssertion: checkTypeAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
+++ b/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
@@ -1,0 +1,49 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+function unwrapParentheses(node: ESTree.Expression): ESTree.Expression {
+  let current = node;
+  while (current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isEmptyObjectExpression(node: ESTree.Expression): boolean {
+  return node.type === "ObjectExpression" && node.properties.length === 0;
+}
+
+function isConditionalEmptyObjectSpread(node: ESTree.Expression): boolean {
+  const conditional = unwrapParentheses(node);
+  return (
+    conditional.type === "ConditionalExpression" &&
+    (isEmptyObjectExpression(conditional.consequent) ||
+      isEmptyObjectExpression(conditional.alternate))
+  );
+}
+
+/** Ban conditional empty-object spreads without changing their omission semantics. */
+export const noConditionalEmptyObjectSpreadRule = defineRule({
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow object spreads that conditionally spread an empty object to omit fields.",
+    },
+    messages: {
+      avoid:
+        "This conditional spread hides property omission behind an empty object. Build the object in separate statements and add the property only when present.",
+    },
+  },
+  createOnce(context) {
+    return {
+      SpreadElement(node) {
+        if (node.parent.type !== "ObjectExpression") return;
+
+        if (isConditionalEmptyObjectSpread(node.argument)) {
+          context.report({ node, messageId: "avoid" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
+++ b/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
@@ -1,0 +1,427 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	classifyUnsafeDictionaryValue,
+	classifyWideningTarget,
+	createTypeEnvironment,
+	isKnownEvidenceExpression,
+	type TypeEnvironment,
+	type WideningTarget,
+} from "../shared/dictionary-types.ts";
+import {
+	containsUnknownType,
+	functionParameterBindingName,
+	functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
+
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+type FunctionExpression = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function unwrapExpression(expression: ESTree.Expression): ESTree.Expression {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSSatisfiesExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression"
+	) {
+		current = current.expression;
+	}
+	return current;
+}
+
+function resolveVariable(
+	sourceCode: SourceCode,
+	identifier: ESTree.IdentifierReference,
+): Variable | null {
+	let scope: Scope | null = sourceCode.getScope(identifier);
+	while (scope !== null) {
+		const variable = scope.set.get(identifier.name);
+		if (variable !== undefined) return variable;
+		scope = scope.upper;
+	}
+	return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+	if (variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	return definition?.type === "Variable" && definition.node.type === "VariableDeclarator"
+		? definition.node
+		: null;
+}
+
+function isStableConstVariable(variable: Variable, declarator: ESTree.VariableDeclarator): boolean {
+	return (
+		declarator.parent.type === "VariableDeclaration" &&
+		declarator.parent.kind === "const" &&
+		variable.references.every((reference) => reference.init || !reference.isWrite())
+	);
+}
+
+function hasKnownEvidence(
+	sourceCode: SourceCode,
+	expression: ESTree.Expression,
+	visitedVariables = new Set<Variable>(),
+): boolean {
+	if (isKnownEvidenceExpression(expression)) return true;
+	const unwrapped = unwrapExpression(expression);
+	if (unwrapped.type !== "Identifier") return false;
+	const variable = resolveVariable(sourceCode, unwrapped);
+	if (variable === null || visitedVariables.has(variable)) return false;
+	const declarator = variableDeclarator(variable);
+	if (
+		declarator === null ||
+		declarator.init === null ||
+		!isStableConstVariable(variable, declarator)
+	) {
+		return false;
+	}
+	visitedVariables.add(variable);
+	return hasKnownEvidence(sourceCode, declarator.init, visitedVariables);
+}
+
+function isFunctionExpression(node: ESTree.Node): node is FunctionExpression {
+	return (
+		node.type === "ArrowFunctionExpression" ||
+		node.type === "FunctionDeclaration" ||
+		node.type === "FunctionExpression" ||
+		node.type === "TSDeclareFunction" ||
+		node.type === "TSEmptyBodyFunctionExpression"
+	);
+}
+
+function localFunctionForCall(
+	sourceCode: SourceCode,
+	callee: ESTree.Expression,
+): FunctionExpression | null {
+	const unwrapped = unwrapExpression(callee);
+	if (isFunctionExpression(unwrapped)) return unwrapped;
+	if (unwrapped.type !== "Identifier") return null;
+	const variable = resolveVariable(sourceCode, unwrapped);
+	if (variable === null || variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	if (definition === undefined) return null;
+	if (definition.type === "FunctionName" && isFunctionExpression(definition.node)) {
+		return definition.node;
+	}
+	if (definition.type !== "Variable" || definition.node.type !== "VariableDeclarator") {
+		return null;
+	}
+	const initializer = definition.node.init;
+	if (initializer === null) return null;
+	const unwrappedInitializer = unwrapExpression(initializer);
+	return isFunctionExpression(unwrappedInitializer) ? unwrappedInitializer : null;
+}
+
+function variableTypeAnnotation(
+	sourceCode: SourceCode,
+	variable: Variable,
+): ESTree.TSTypeAnnotation | null {
+	if (variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	if (definition === undefined) return null;
+	if (
+		definition.type === "Variable" &&
+		definition.node.type === "VariableDeclarator" &&
+		definition.node.id.type === "Identifier"
+	) {
+		return definition.node.id.typeAnnotation ?? null;
+	}
+	if (definition.type !== "Parameter" || !isFunctionExpression(definition.node)) {
+		return null;
+	}
+	const parameter = definition.node.params.find(
+		(candidate) =>
+			functionParameterBindingName(candidate, sourceCode) === variable.name,
+	);
+	return parameter === undefined ? null : (functionParameterTypeAnnotation(parameter) ?? null);
+}
+
+function hasInformativeType(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): boolean {
+	return classifyUnsafeDictionaryValue(type, environment) === null;
+}
+
+function hasKnownCallArgumentEvidence(
+	sourceCode: SourceCode,
+	expression: ESTree.Expression,
+	environment: TypeEnvironment,
+	visitedVariables = new Set<Variable>(),
+): boolean {
+	if (expression.type === "ParenthesizedExpression" || expression.type === "TSNonNullExpression") {
+		return hasKnownCallArgumentEvidence(
+			sourceCode,
+			expression.expression,
+			environment,
+			visitedVariables,
+		);
+	}
+	if (expression.type === "TSAsExpression" || expression.type === "TSTypeAssertion") {
+		return hasInformativeType(expression.typeAnnotation, environment);
+	}
+	if (expression.type === "TSSatisfiesExpression") {
+		return hasKnownCallArgumentEvidence(
+			sourceCode,
+			expression.expression,
+			environment,
+			visitedVariables,
+		);
+	}
+	if (expression.type === "CallExpression") {
+		const owner = localFunctionForCall(sourceCode, expression.callee);
+		const returnType = owner?.returnType?.typeAnnotation;
+		return returnType !== undefined && hasInformativeType(returnType, environment);
+	}
+	if (expression.type !== "Identifier") return isKnownEvidenceExpression(expression);
+	const variable = resolveVariable(sourceCode, expression);
+	if (variable === null || visitedVariables.has(variable)) return false;
+	const annotation = variableTypeAnnotation(sourceCode, variable);
+	if (annotation !== null) {
+		return hasInformativeType(annotation.typeAnnotation, environment);
+	}
+	const declarator = variableDeclarator(variable);
+	if (
+		declarator === null ||
+		declarator.init === null ||
+		!isStableConstVariable(variable, declarator)
+	) {
+		return false;
+	}
+	visitedVariables.add(variable);
+	return hasKnownCallArgumentEvidence(
+		sourceCode,
+		declarator.init,
+		environment,
+		visitedVariables,
+	);
+}
+
+function typePredicateSubjectIndex(
+	sourceCode: SourceCode,
+	owner: FunctionExpression,
+): number | null {
+	const predicate = owner.returnType?.typeAnnotation;
+	if (predicate?.type !== "TSTypePredicate" || predicate.parameterName.type !== "Identifier") {
+		return null;
+	}
+	const predicateParameterName = predicate.parameterName.name;
+	const index = owner.params.findIndex(
+		(parameter) =>
+			functionParameterBindingName(parameter, sourceCode) === predicateParameterName,
+	);
+	return index === -1 ? null : index;
+}
+
+function annotationTarget(
+	annotation: ESTree.TSTypeAnnotation | null | undefined,
+	environment: TypeEnvironment,
+): WideningTarget | null {
+	return annotation === null || annotation === undefined
+		? null
+		: classifyWideningTarget(annotation.typeAnnotation, environment);
+}
+
+function enclosingFunction(node: ESTree.Node): FunctionExpression | null {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (
+			current.type === "ArrowFunctionExpression" ||
+			current.type === "FunctionDeclaration" ||
+			current.type === "FunctionExpression"
+		) {
+			return current;
+		}
+		current = current.parent;
+	}
+	return null;
+}
+
+function sourceKeyName(sourceCode: SourceCode, key: ESTree.PropertyKey): string {
+	if (key.type === "Identifier" || key.type === "PrivateIdentifier") return key.name;
+	if (key.type === "Literal") return String(key.value);
+	return sourceCode.getText(key);
+}
+
+function functionName(sourceCode: SourceCode, owner: FunctionExpression | null): string {
+	if (owner === null) return "anonymous function";
+	if (owner.id !== null) return owner.id.name;
+	const parent = owner.parent;
+	if (parent.type === "VariableDeclarator" && parent.id.type === "Identifier")
+		return parent.id.name;
+	if (parent.type === "MethodDefinition") return sourceKeyName(sourceCode, parent.key);
+	return "anonymous function";
+}
+
+function isEmptyObjectExpression(expression: ESTree.Expression): boolean {
+	const unwrapped = unwrapExpression(expression);
+	return unwrapped.type === "ObjectExpression" && unwrapped.properties.length === 0;
+}
+
+function isDictionaryAccumulatorTarget(destination: WideningTarget): boolean {
+	return destination.kind === "open dictionary" || destination.kind === "generic container";
+}
+
+function hasParentAssertion(node: ESTree.Node): boolean {
+	return node.parent?.type === "TSAsExpression" || node.parent?.type === "TSTypeAssertion";
+}
+
+/** Detect sound syntactic cases where a known value is explicitly widened and loses evidence. */
+export const noKnownValueWideningRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow syntactically established values from flowing into explicitly broad or anonymous target types that discard useful evidence.",
+		},
+		messages: {
+			widening:
+				"The explicit {{target}} type on {{subject}} discards known type evidence. Keep inference, validate with `satisfies`, or use a named owner contract.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeEnvironment | null = null;
+
+		const reportFlow = (
+			expression: ESTree.Expression,
+			destination: WideningTarget | null,
+			subject: string,
+		) => {
+			if (destination === null) return;
+			if (
+				isDictionaryAccumulatorTarget(destination) &&
+				isEmptyObjectExpression(expression)
+			) {
+				return;
+			}
+			if (!hasKnownEvidence(context.sourceCode, expression)) return;
+			context.report({
+				node: expression,
+				messageId: "widening",
+				data: { subject, target: destination.kind },
+			});
+		};
+
+		const targetFromAnnotation = (annotation: ESTree.TSTypeAnnotation | null | undefined) =>
+			environment === null ? null : annotationTarget(annotation, environment);
+
+		return {
+			Program(node) {
+				environment = createTypeEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			VariableDeclarator(node) {
+				if (node.init === null || node.id.type !== "Identifier") return;
+				reportFlow(
+					node.init,
+					targetFromAnnotation(node.id.typeAnnotation),
+					`binding \`${node.id.name}\``,
+				);
+			},
+			PropertyDefinition(node) {
+				if (node.value === null) return;
+				reportFlow(
+					node.value,
+					targetFromAnnotation(node.typeAnnotation),
+					`property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+				);
+			},
+			AccessorProperty(node) {
+				if (node.value === null) return;
+				reportFlow(
+					node.value,
+					targetFromAnnotation(node.typeAnnotation),
+					`property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+				);
+			},
+			AssignmentExpression(node) {
+				if (node.operator !== "=" || node.left.type !== "Identifier") return;
+				const variable = resolveVariable(context.sourceCode, node.left);
+				if (variable === null) return;
+				const declarator = variableDeclarator(variable);
+				if (declarator === null || declarator.id.type !== "Identifier") return;
+				reportFlow(
+					node.right,
+					targetFromAnnotation(declarator.id.typeAnnotation),
+					`binding \`${declarator.id.name}\``,
+				);
+			},
+			CallExpression(node) {
+				if (environment === null) return;
+				const owner = localFunctionForCall(context.sourceCode, node.callee);
+				if (owner === null) return;
+				const parameterIndex = typePredicateSubjectIndex(context.sourceCode, owner);
+				if (parameterIndex === null) return;
+				const parameter = owner.params[parameterIndex];
+				const argument = node.arguments[parameterIndex];
+				if (parameter === undefined || argument === undefined || argument.type === "SpreadElement") {
+					return;
+				}
+				const parameterAnnotation = functionParameterTypeAnnotation(parameter);
+				if (
+					parameterAnnotation === null ||
+					parameterAnnotation === undefined ||
+					!containsUnknownType(parameterAnnotation.typeAnnotation)
+				) {
+					return;
+				}
+				if (
+					!hasKnownCallArgumentEvidence(
+						context.sourceCode,
+						argument,
+						environment,
+					)
+				) {
+					return;
+				}
+				context.report({
+					node: argument,
+					messageId: "widening",
+					data: {
+						subject: `argument for parameter \`${functionParameterBindingName(parameter, context.sourceCode)}\` of \`${functionName(context.sourceCode, owner)}\``,
+						target: "unknown",
+					},
+				});
+			},
+			ReturnStatement(node) {
+				if (node.argument === null) return;
+				const owner = enclosingFunction(node);
+				reportFlow(
+					node.argument,
+					targetFromAnnotation(owner?.returnType),
+					`return value of \`${functionName(context.sourceCode, owner)}\``,
+				);
+			},
+			ArrowFunctionExpression(node) {
+				if (node.body.type === "BlockStatement") return;
+				reportFlow(
+					node.body,
+					targetFromAnnotation(node.returnType),
+					`return value of \`${functionName(context.sourceCode, node)}\``,
+				);
+			},
+			TSAsExpression(node) {
+				if (environment === null || hasParentAssertion(node)) return;
+				reportFlow(
+					node.expression,
+					classifyWideningTarget(node.typeAnnotation, environment),
+					"assertion",
+				);
+			},
+			TSTypeAssertion(node) {
+				if (environment === null || hasParentAssertion(node)) return;
+				reportFlow(
+					node.expression,
+					classifyWideningTarget(node.typeAnnotation, environment),
+					"assertion",
+				);
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-module-mocking.ts
+++ b/tools/oxlint/anti-slop/rules/no-module-mocking.ts
@@ -1,0 +1,91 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+const moduleMockMethods = new Set(["doMock", "mock", "unstable_mockModule"]);
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function importedName(node: ESTree.Node): string | null {
+  if (node.type !== "ImportSpecifier") return null;
+  return node.imported.type === "Identifier" ? node.imported.name : node.imported.value;
+}
+
+function isTestFrameworkObject(
+  sourceCode: SourceCode,
+  expression: ESTree.Expression,
+): expression is ESTree.IdentifierReference {
+  if (expression.type !== "Identifier") return false;
+  if (
+    (expression.name === "vi" || expression.name === "jest") &&
+    sourceCode.isGlobalReference(expression)
+  ) {
+    return true;
+  }
+
+  const variable = resolveVariable(sourceCode, expression);
+  if (variable === null || variable.defs.length === 0) {
+    return expression.name === "vi" || expression.name === "jest";
+  }
+  return variable.defs.some((definition) => {
+    if (definition.type !== "ImportBinding" || definition.parent?.type !== "ImportDeclaration") {
+      return false;
+    }
+    const source = definition.parent.source.value;
+    const name = importedName(definition.node);
+    return (source === "vitest" && name === "vi") || (source === "@jest/globals" && name === "jest");
+  });
+}
+
+function moduleMockCall(sourceCode: SourceCode, callee: ESTree.Expression): boolean {
+  if (!("property" in callee) || !("object" in callee) || !("computed" in callee)) return false;
+  if (!isTestFrameworkObject(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  const method = callee.computed
+    ? property.type === "Literal" &&
+      (property.value === "doMock" ||
+        property.value === "mock" ||
+        property.value === "unstable_mockModule")
+      ? property.value
+      : null
+    : property.type === "Identifier"
+      ? property.name
+      : null;
+  return method !== null && moduleMockMethods.has(method);
+}
+
+/** Ban test framework module mocking in favor of real dependency seams. */
+export const noModuleMockingRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Vitest and Jest module mocking; tests must replace dependencies through real interfaces.",
+    },
+    messages: {
+      moduleMock:
+        "Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (moduleMockCall(context.sourceCode, node.callee)) {
+          context.report({ node, messageId: "moduleMock" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-object-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-object-parameters.ts
@@ -1,0 +1,83 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+	functionParameterBindingName,
+	functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
+import {
+	createTypeAliasEnvironment,
+	resolvedTypeMatches,
+	type TypeAliasEnvironment,
+} from "../shared/type-alias-resolution.ts";
+type ParameterOwner =
+	| ESTree.ArrowFunctionExpression
+	| ESTree.Function
+	| ESTree.TSCallSignatureDeclaration
+	| ESTree.TSConstructSignatureDeclaration
+	| ESTree.TSConstructorType
+	| ESTree.TSFunctionType
+	| ESTree.TSMethodSignature;
+
+/** Ban the broad object type on function inputs, including local aliases to object. */
+export const noObjectParametersRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow object function parameters; inputs must use an owner-provided type and be parsed at their boundary.",
+		},
+		messages: {
+			objectParameter:
+				"Parameter `{{parameter}}` uses the broad `object` type. Accept a named owner type; parse external input at its boundary before calling this function.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeAliasEnvironment | null = null;
+
+		const resolvesToObject = (type: ESTree.TSType): boolean =>
+			environment !== null &&
+			resolvedTypeMatches(type, environment, (resolved, matches) => {
+				if (resolved.type === "TSObjectKeyword") return true;
+				if (resolved.type === "TSParenthesizedType") {
+					return matches(resolved.typeAnnotation);
+				}
+				return (
+					resolved.type === "TSUnionType" && resolved.types.some(matches)
+				);
+			});
+
+		const checkParameters = (node: ParameterOwner) => {
+			for (const parameter of node.params) {
+				const annotation = functionParameterTypeAnnotation(parameter);
+				if (annotation === null || annotation === undefined) continue;
+				if (!resolvesToObject(annotation.typeAnnotation)) continue;
+				context.report({
+					node: annotation.typeAnnotation,
+					messageId: "objectParameter",
+					data: { parameter: functionParameterBindingName(parameter, context.sourceCode) },
+				});
+			}
+		};
+
+		return {
+			Program(node) {
+				environment = createTypeAliasEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			ArrowFunctionExpression: checkParameters,
+			FunctionDeclaration: checkParameters,
+			FunctionExpression: checkParameters,
+			TSCallSignatureDeclaration: checkParameters,
+			TSConstructSignatureDeclaration: checkParameters,
+			TSConstructorType: checkParameters,
+			TSDeclareFunction: checkParameters,
+			TSEmptyBodyFunctionExpression: checkParameters,
+			TSFunctionType: checkParameters,
+			TSMethodSignature: checkParameters,
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
@@ -1,0 +1,28 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { isGlobalReflectMethodCall } from "../shared/reflect-method.ts";
+
+/** Ban Reflect.apply, which bypasses ordinary typed function calls. */
+export const noReflectApplyRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Reflect.apply; call typed functions directly or model dynamic dispatch behind an interface.",
+    },
+    messages: {
+      reflectApply:
+        "Replace `Reflect.apply` with a typed function call. Model dynamic dispatch behind a named interface.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, "apply")) {
+          context.report({ node, messageId: "reflectApply" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-get.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-get.ts
@@ -1,0 +1,28 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { isGlobalReflectMethodCall } from "../shared/reflect-method.ts";
+
+/** Ban Reflect.get, which bypasses ordinary property access and useful type evidence. */
+export const noReflectGetRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Reflect.get; use typed property access or parse dynamic input into a domain type.",
+    },
+    messages: {
+      reflectGet:
+        "Replace `Reflect.get` with typed property access. Parse dynamic input into a named domain type before reading it.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, "get")) {
+          context.report({ node, messageId: "reflectGet" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
+++ b/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
@@ -1,0 +1,77 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+type RuntimeFunction = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function isRuntimeFunction(node: ESTree.Node): node is RuntimeFunction {
+	return (
+		node.type === "ArrowFunctionExpression" ||
+		node.type === "FunctionDeclaration" ||
+		node.type === "FunctionExpression"
+	);
+}
+
+function isInsideTypeGuard(node: ESTree.Node): boolean {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (isRuntimeFunction(current)) {
+			return current.returnType?.typeAnnotation.type === "TSTypePredicate";
+		}
+		current = current.parent;
+	}
+	return false;
+}
+
+/** Return whether typeof safely probes for the existence of a possibly absent binding. */
+function isExistenceProbe(node: ESTree.UnaryExpression): boolean {
+	const parent = node.parent;
+	if (parent.type !== "BinaryExpression") return false;
+	if (!["===", "!==", "==", "!="].includes(parent.operator)) return false;
+	const other = parent.left === node ? parent.right : parent.left;
+	return other.type === "Literal" && other.value === "undefined";
+}
+
+/** Disallow runtime typeof checks that narrow unparsed values instead of decoding them. */
+export const noRuntimeTypeofRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow runtime typeof checks; external values must be decoded into meaningful types at their I/O boundary.",
+		},
+		messages: {
+			runtimeTypeof:
+				"A `typeof` check narrows a representation without establishing its contract. Parse input at its I/O boundary, then branch on the domain value.",
+		},
+		schema: [
+			{
+				type: "object",
+				properties: {
+					allowInTypeGuards: { type: "boolean" },
+				},
+				additionalProperties: false,
+			},
+		],
+		defaultOptions: [{ allowInTypeGuards: false }],
+	},
+	createOnce(context) {
+		return {
+			UnaryExpression(node) {
+				const option = context.options?.[0];
+				const allowInTypeGuards =
+					typeof option === "object" &&
+					option !== null &&
+					!Array.isArray(option) &&
+					option.allowInTypeGuards === true;
+				if (
+					node.operator === "typeof" &&
+					!isExistenceProbe(node) &&
+					(!allowInTypeGuards || !isInsideTypeGuard(node))
+				) {
+					context.report({ node, messageId: "runtimeTypeof" });
+				}
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
+++ b/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
@@ -1,0 +1,46 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+const FORBIDDEN_SYMBOL_NAME = "shape";
+
+function containsForbiddenSymbolName(name: string): boolean {
+  return name.toLowerCase().includes(FORBIDDEN_SYMBOL_NAME);
+}
+
+/** Return whether an identifier names a statically accessed member owned by another value. */
+function isBorrowedMemberName(node: ESTree.Node): boolean {
+  const parent = node.parent;
+  if (parent === null || parent.type !== "MemberExpression") return false;
+  return parent.property === node && parent.computed === false;
+}
+
+/** Ban the case-insensitive substring "shape" in every JavaScript and TypeScript symbol name. */
+export const noForbiddenTermInSymbolNamesRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        'Disallow the case-insensitive substring "shape" in JavaScript, TypeScript, private, and JSX symbol names.',
+    },
+    messages: {
+      forbiddenSymbolName:
+        'Rename symbol "{{name}}" for its domain role; "shape" describes structure rather than ownership.',
+    },
+  },
+  createOnce(context) {
+    const reportForbiddenSymbolName = (node: ESTree.Node & { name: string }) => {
+      if (!containsForbiddenSymbolName(node.name) || isBorrowedMemberName(node)) return;
+      context.report({
+        node,
+        messageId: "forbiddenSymbolName",
+        data: { name: node.name },
+      });
+    };
+
+    return {
+      Identifier: reportForbiddenSymbolName,
+      PrivateIdentifier: reportForbiddenSymbolName,
+      JSXIdentifier: reportForbiddenSymbolName,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
@@ -1,0 +1,69 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+  containsUnknownType,
+  functionParameterBindingName,
+  functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
+type ParameterOwner =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function isTypePredicateSubject(owner: ParameterOwner, parameterName: string): boolean {
+  const predicate = owner.returnType?.typeAnnotation;
+  return (
+    predicate?.type === "TSTypePredicate" &&
+    predicate.parameterName.type === "Identifier" &&
+    predicate.parameterName.name === parameterName
+  );
+}
+
+/** Disallow unknown inputs except explicitly named error-cause enrichment. */
+export const noUnknownParametersRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow explicitly unknown function parameters except `cause` and type-predicate subjects; decode unknown input at its I/O boundary instead.",
+    },
+    messages: {
+      unknownParameter:
+        "Parameter `{{parameter}}` leaves input unparsed. Accept a named domain type; run the expected schema or parser at the I/O boundary before calling this function.",
+    },
+  },
+  createOnce(context) {
+    const checkParameters = (node: ParameterOwner) => {
+      for (const parameter of node.params) {
+        const annotation = functionParameterTypeAnnotation(parameter);
+        if (annotation === null || annotation === undefined) continue;
+        if (!containsUnknownType(annotation.typeAnnotation)) continue;
+        const name = functionParameterBindingName(parameter, context.sourceCode);
+        if (name === "cause" || isTypePredicateSubject(node, name)) continue;
+        context.report({
+          node: annotation.typeAnnotation,
+          messageId: "unknownParameter",
+          data: { parameter: name },
+        });
+      }
+    };
+
+    return {
+      ArrowFunctionExpression: checkParameters,
+      FunctionDeclaration: checkParameters,
+      FunctionExpression: checkParameters,
+      TSCallSignatureDeclaration: checkParameters,
+      TSConstructSignatureDeclaration: checkParameters,
+      TSConstructorType: checkParameters,
+      TSDeclareFunction: checkParameters,
+      TSEmptyBodyFunctionExpression: checkParameters,
+      TSFunctionType: checkParameters,
+      TSMethodSignature: checkParameters,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
@@ -1,0 +1,82 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+  createTypeAliasEnvironment,
+  resolvedTypeMatches,
+  type TypeAliasEnvironment,
+} from "../shared/type-alias-resolution.ts";
+
+type FunctionWithReturnType =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+/** Ban function contracts that return unknown instead of a parsed domain type. */
+export const noUnknownReturnsRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow functions whose explicit return contract is unknown or Promise<unknown>.",
+    },
+    messages: {
+      unknownReturn:
+        "This function exposes `unknown` to its caller. Parse the value at its boundary and return a named domain type.",
+    },
+  },
+  createOnce(context) {
+    let environment: TypeAliasEnvironment | null = null;
+
+    const resolvesToUnknown = (type: ESTree.TSType): boolean =>
+      environment !== null &&
+      resolvedTypeMatches(type, environment, (resolved, matches) => {
+        if (resolved.type === "TSUnknownKeyword") return true;
+        if (resolved.type === "TSParenthesizedType") {
+          return matches(resolved.typeAnnotation);
+        }
+        if (resolved.type === "TSUnionType") return resolved.types.some(matches);
+        if (
+          resolved.type !== "TSTypeReference" ||
+          resolved.typeName.type !== "Identifier" ||
+          (resolved.typeName.name !== "Promise" &&
+            resolved.typeName.name !== "PromiseLike")
+        ) {
+          return false;
+        }
+        const value = resolved.typeArguments?.params[0];
+        return value !== undefined && matches(value);
+      });
+
+    const checkReturnType = (node: FunctionWithReturnType) => {
+      const annotation = node.returnType;
+      if (annotation === null || annotation === undefined) return;
+      if (!resolvesToUnknown(annotation.typeAnnotation)) return;
+      context.report({ node: annotation.typeAnnotation, messageId: "unknownReturn" });
+    };
+
+    return {
+      Program(node) {
+        environment = createTypeAliasEnvironment(
+          node,
+          context.sourceCode.visitorKeys,
+        );
+      },
+      ArrowFunctionExpression: checkReturnType,
+      FunctionDeclaration: checkReturnType,
+      FunctionExpression: checkReturnType,
+      TSCallSignatureDeclaration: checkReturnType,
+      TSConstructSignatureDeclaration: checkReturnType,
+      TSConstructorType: checkReturnType,
+      TSDeclareFunction: checkReturnType,
+      TSEmptyBodyFunctionExpression: checkReturnType,
+      TSFunctionType: checkReturnType,
+      TSMethodSignature: checkReturnType,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
@@ -1,0 +1,54 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+	createTypeAliasEnvironment,
+	resolvedTypeMatches,
+	type TypeAliasEnvironment,
+} from "../shared/type-alias-resolution.ts";
+
+/** Ban named aliases that merely conceal TypeScript's unknown top type. */
+export const noUnknownTypeAliasesRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow type aliases whose resolved type is unknown; unknown must remain visible at an allowed boundary.",
+		},
+		messages: {
+			unknownAlias:
+				"Type alias `{{alias}}` hides `unknown`. Keep `unknown` explicit at the parsing boundary or on an allowed `cause` field; otherwise use the parsed owner type.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeAliasEnvironment | null = null;
+
+		const resolvesToUnknown = (type: ESTree.TSType): boolean =>
+			environment !== null &&
+			resolvedTypeMatches(type, environment, (resolved, matches) => {
+				if (resolved.type === "TSUnknownKeyword") return true;
+				if (resolved.type === "TSParenthesizedType") {
+					return matches(resolved.typeAnnotation);
+				}
+				return resolved.type === "TSUnionType" && resolved.types.some(matches);
+			});
+
+		return {
+			Program(node) {
+				environment = createTypeAliasEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			TSTypeAliasDeclaration(node) {
+				if (!resolvesToUnknown(node.typeAnnotation)) return;
+				context.report({
+					node: node.id,
+					messageId: "unknownAlias",
+					data: { alias: node.id.name },
+				});
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
+++ b/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
@@ -1,0 +1,154 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	classifyUnsafeDictionary,
+	classifyUnsafeDictionaryValue,
+	createTypeEnvironment,
+	type TypeEnvironment,
+} from "../shared/dictionary-types.ts";
+import { visibleTypeAlias } from "../shared/type-alias-resolution.ts";
+
+import type { ESTree } from "@oxlint/plugins";
+
+const typeNodeKinds: ReadonlySet<string> = new Set([
+	"JSDocNonNullableType",
+	"JSDocNullableType",
+	"JSDocUnknownType",
+	"TSAnyKeyword",
+	"TSArrayType",
+	"TSBigIntKeyword",
+	"TSBooleanKeyword",
+	"TSConditionalType",
+	"TSConstructorType",
+	"TSFunctionType",
+	"TSImportType",
+	"TSIndexedAccessType",
+	"TSInferType",
+	"TSIntersectionType",
+	"TSIntrinsicKeyword",
+	"TSLiteralType",
+	"TSMappedType",
+	"TSNamedTupleMember",
+	"TSNeverKeyword",
+	"TSNullKeyword",
+	"TSNumberKeyword",
+	"TSObjectKeyword",
+	"TSParenthesizedType",
+	"TSStringKeyword",
+	"TSSymbolKeyword",
+	"TSTemplateLiteralType",
+	"TSThisType",
+	"TSTupleType",
+	"TSTypeLiteral",
+	"TSTypeOperator",
+	"TSTypePredicate",
+	"TSTypeQuery",
+	"TSTypeReference",
+	"TSUndefinedKeyword",
+	"TSUnionType",
+	"TSUnknownKeyword",
+	"TSVoidKeyword",
+]);
+
+function isTypeNode(node: ESTree.Node): node is ESTree.TSType {
+	return typeNodeKinds.has(node.type);
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isInsideTypeAliasDeclaration(node: ESTree.Node): boolean {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (current.type === "TSTypeAliasDeclaration") return true;
+		current = current.parent;
+	}
+	return false;
+}
+
+function isPlainAliasConsumerUse(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+	if (node.type !== "TSTypeReference" || node.typeArguments?.params.length) return false;
+	const name = typeReferenceName(node);
+	return (
+		name !== null &&
+		visibleTypeAlias(name, node, environment.typeAliases) !== null &&
+		!isInsideTypeAliasDeclaration(node)
+	);
+}
+
+function isInsideTypeParameterConstraint(node: ESTree.TSType): boolean {
+	let child: ESTree.Node = node;
+	let parent: ESTree.Node | null = child.parent;
+	while (parent !== null && parent.type !== "Program") {
+		if (parent.type === "TSTypeParameter" && parent.constraint === child) return true;
+		child = parent;
+		parent = child.parent;
+	}
+	return false;
+}
+
+function shouldReportType(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+	if (isInsideTypeParameterConstraint(node)) return false;
+	if (isPlainAliasConsumerUse(node, environment)) return false;
+	if (classifyUnsafeDictionary(node, environment) === null) return false;
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (isTypeNode(current) && classifyUnsafeDictionary(current, environment) !== null)
+			return false;
+		current = current.parent;
+	}
+	return true;
+}
+
+/** Disallow object-dictionary contracts whose direct value type is an unsafe escape hatch. */
+export const noUnsafeDictionaryTypeRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow object-dictionary contracts whose direct value type is unknown, any, object, {}, or a union/alias containing one of those escape hatches.",
+		},
+		messages: {
+			unsafeDictionary:
+				"This dictionary's {{value}} value type gives callers no concrete value contract. Use an owner/schema-derived value type; parse external payloads before insertion.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeEnvironment | null = null;
+		const report = (node: ESTree.Node, value: string) => {
+			context.report({ node, messageId: "unsafeDictionary", data: { value } });
+		};
+		const reportIfUnsafe = (node: ESTree.TSType) => {
+			if (environment === null || !shouldReportType(node, environment)) return;
+			const unsafe = classifyUnsafeDictionary(node, environment);
+			if (unsafe === null) return;
+			report(node, unsafe.unsafeValue);
+		};
+
+		return {
+			Program(node) {
+				environment = createTypeEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			TSTypeReference: reportIfUnsafe,
+			TSTypeLiteral: reportIfUnsafe,
+			TSMappedType: reportIfUnsafe,
+			TSIndexSignature(node) {
+				if (
+					environment === null ||
+					node.typeAnnotation === null ||
+					node.parent.type === "TSTypeLiteral"
+				)
+					return;
+				const unsafe = classifyUnsafeDictionaryValue(
+					node.typeAnnotation.typeAnnotation,
+					environment,
+				);
+				if (unsafe !== null) report(node, unsafe.unsafeValue);
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
@@ -1,0 +1,366 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, Variable } from "@oxlint/plugins";
+
+type BroadTypeKind = "top" | "object" | "record";
+
+type KnownValueEvidence = {
+  readonly type: ESTree.TSType | null;
+};
+
+const functionBoundaryTypes = new Set([
+  "ArrowFunctionExpression",
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "TSDeclareFunction",
+  "TSEmptyBodyFunctionExpression",
+]);
+
+function unwrapExpressionParentheses(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") current = current.expression;
+  return current;
+}
+
+function unwrapTypeParentheses(type: ESTree.TSType): ESTree.TSType {
+  let current = type;
+  while (current.type === "TSParenthesizedType") current = current.typeAnnotation;
+  return current;
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isUnknownOrAnyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  return unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword";
+}
+
+function isBroadRecordKeyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (
+    unwrapped.type === "TSStringKeyword" ||
+    unwrapped.type === "TSNumberKeyword" ||
+    unwrapped.type === "TSSymbolKeyword"
+  ) {
+    return true;
+  }
+  if (unwrapped.type === "TSUnionType") return unwrapped.types.every(isBroadRecordKeyType);
+  return unwrapped.type === "TSTypeReference" && typeReferenceName(unwrapped) === "PropertyKey";
+}
+
+function isBroadRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+
+  if (unwrapped.type === "TSTypeReference") {
+    if (typeReferenceName(unwrapped) === "Readonly") {
+      const [inner] = unwrapped.typeArguments?.params ?? [];
+      return inner !== undefined && isBroadRecordType(inner);
+    }
+
+    if (typeReferenceName(unwrapped) !== "Record") return false;
+    const parameters = unwrapped.typeArguments?.params ?? [];
+    return (
+      parameters.length === 2 &&
+      parameters[0] !== undefined &&
+      parameters[1] !== undefined &&
+      isBroadRecordKeyType(parameters[0]) &&
+      isUnknownOrAnyType(parameters[1])
+    );
+  }
+
+  if (unwrapped.type !== "TSTypeLiteral" || unwrapped.members.length !== 1) return false;
+  const [member] = unwrapped.members;
+  const [parameter] = member?.type === "TSIndexSignature" ? member.parameters : [];
+  return (
+    member?.type === "TSIndexSignature" &&
+    member.parameters.length === 1 &&
+    parameter !== undefined &&
+    isBroadRecordKeyType(parameter.typeAnnotation.typeAnnotation) &&
+    isUnknownOrAnyType(member.typeAnnotation.typeAnnotation)
+  );
+}
+
+function broadTypeKind(type: ESTree.TSType): BroadTypeKind | null {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword") return "top";
+  if (unwrapped.type === "TSObjectKeyword") return "object";
+  return isBroadRecordType(unwrapped) ? "record" : null;
+}
+
+function assertedExpression(
+  node: ESTree.TSAsExpression | ESTree.TSTypeAssertion,
+): ESTree.Expression {
+  return unwrapExpressionParentheses(node.expression);
+}
+
+function assertionFromExpression(
+  expression: ESTree.Expression,
+): ESTree.TSAsExpression | ESTree.TSTypeAssertion | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+  return unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion"
+    ? unwrapped
+    : null;
+}
+
+function normalizedTypeText(sourceText: string, type: ESTree.TSType): string {
+  return sourceText.slice(type.start, type.end).replaceAll(/\s+/gu, "");
+}
+
+function typesHaveSameSyntax(
+  sourceText: string,
+  left: ESTree.TSType | null,
+  right: ESTree.TSType,
+): boolean {
+  return (
+    left !== null &&
+    normalizedTypeText(sourceText, unwrapTypeParentheses(left)) ===
+      normalizedTypeText(sourceText, unwrapTypeParentheses(right))
+  );
+}
+
+function isDefinitelyObjectType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  switch (unwrapped.type) {
+    case "TSArrayType":
+    case "TSConstructorType":
+    case "TSFunctionType":
+    case "TSMappedType":
+    case "TSObjectKeyword":
+    case "TSTupleType":
+      return true;
+    case "TSTypeLiteral":
+      return unwrapped.members.length > 0;
+    case "TSIntersectionType":
+      return unwrapped.types.every(isDefinitelyObjectType);
+    case "TSTypeOperator":
+      return unwrapped.operator === "readonly" && isDefinitelyObjectType(unwrapped.typeAnnotation);
+    default:
+      return false;
+  }
+}
+
+function isDefinitelyNarrowerRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSTypeLiteral") {
+    return unwrapped.members.some((member) => member.type !== "TSIndexSignature");
+  }
+
+  if (unwrapped.type !== "TSTypeReference") return false;
+  if (typeReferenceName(unwrapped) === "Readonly") {
+    const [inner] = unwrapped.typeArguments?.params ?? [];
+    return inner !== undefined && isDefinitelyNarrowerRecordType(inner);
+  }
+  if (typeReferenceName(unwrapped) !== "Record") return false;
+
+  const parameters = unwrapped.typeArguments?.params ?? [];
+  return (
+    parameters.length === 2 && parameters[1] !== undefined && !isUnknownOrAnyType(parameters[1])
+  );
+}
+
+function functionBoundary(node: ESTree.Node): ESTree.Node | null {
+  let current = node.parent;
+  while (current !== null && current.type !== "Program") {
+    if (functionBoundaryTypes.has(current.type)) return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+function resolvedVariableForIdentifier(
+  scopes: readonly {
+    readonly references: readonly {
+      readonly identifier: ESTree.Node;
+      readonly resolved: Variable | null;
+    }[];
+  }[],
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  for (const scope of scopes) {
+    const reference = scope.references.find(
+      (candidate) =>
+        candidate.identifier.start === identifier.start &&
+        candidate.identifier.end === identifier.end,
+    );
+    if (reference !== undefined) return reference.resolved;
+  }
+  return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+  for (const definition of variable.defs) {
+    if (definition.type === "Variable" && definition.node.type === "VariableDeclarator") {
+      return definition.node;
+    }
+  }
+  return null;
+}
+
+function knownValueEvidence(
+  expression: ESTree.Expression,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+  boundary: ESTree.Node | null,
+  visitedVariables: ReadonlySet<Variable>,
+): KnownValueEvidence | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+
+  if (unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion") {
+    if (broadTypeKind(unwrapped.typeAnnotation) !== null) return null;
+    return { type: unwrapped.typeAnnotation };
+  }
+
+  if (unwrapped.type === "Literal" || unwrapped.type === "TemplateLiteral") {
+    return { type: null };
+  }
+
+  if (
+    unwrapped.type === "ArrayExpression" ||
+    unwrapped.type === "ArrowFunctionExpression" ||
+    unwrapped.type === "ClassExpression" ||
+    unwrapped.type === "FunctionExpression" ||
+    unwrapped.type === "NewExpression" ||
+    unwrapped.type === "ObjectExpression"
+  ) {
+    return { type: null };
+  }
+
+  if (unwrapped.type !== "Identifier") return null;
+  const variable = resolvedVariableForIdentifier(scopes, unwrapped);
+  if (variable === null || visitedVariables.has(variable)) return null;
+
+  const annotatedIdentifier = variable.identifiers.find(
+    (identifier) => identifier.typeAnnotation !== null && identifier.typeAnnotation !== undefined,
+  );
+  const annotation = annotatedIdentifier?.typeAnnotation?.typeAnnotation;
+  if (annotation !== undefined && annotatedIdentifier !== undefined) {
+    if (functionBoundary(annotatedIdentifier) !== boundary || broadTypeKind(annotation) !== null) {
+      return null;
+    }
+    return { type: annotation };
+  }
+
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init) ||
+    functionBoundary(declarator) !== boundary
+  ) {
+    return null;
+  }
+
+  return knownValueEvidence(
+    declarator.init,
+    scopes,
+    boundary,
+    new Set([...visitedVariables, variable]),
+  );
+}
+
+function widenedBinding(
+  variable: Variable,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+): {
+  readonly broadKind: BroadTypeKind;
+  readonly evidence: KnownValueEvidence;
+  readonly declaredAt: number;
+  readonly boundary: ESTree.Node | null;
+} | null {
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.id.type !== "Identifier" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init)
+  ) {
+    return null;
+  }
+
+  const boundary = functionBoundary(declarator);
+  const declaredType = declarator.id.typeAnnotation?.typeAnnotation;
+  const initializerAssertion = assertionFromExpression(declarator.init);
+  const initializerBroadKind =
+    initializerAssertion === null ? null : broadTypeKind(initializerAssertion.typeAnnotation);
+  const declaredBroadKind = declaredType === undefined ? null : broadTypeKind(declaredType);
+  const broadKind = declaredBroadKind ?? initializerBroadKind;
+  if (broadKind === null) return null;
+
+  const originalExpression =
+    initializerAssertion !== null && initializerBroadKind !== null
+      ? assertedExpression(initializerAssertion)
+      : declarator.init;
+  const evidence = knownValueEvidence(originalExpression, scopes, boundary, new Set([variable]));
+  return evidence === null ? null : { broadKind, evidence, declaredAt: declarator.end, boundary };
+}
+
+function assertionIsNarrower(
+  sourceText: string,
+  broadKind: BroadTypeKind,
+  evidence: KnownValueEvidence,
+  assertedType: ESTree.TSType,
+): boolean {
+  if (broadTypeKind(assertedType) !== null) return false;
+  if (broadKind === "top") return true;
+  if (typesHaveSameSyntax(sourceText, evidence.type, assertedType)) return true;
+  if (broadKind === "object") return isDefinitelyObjectType(assertedType);
+  return isDefinitelyNarrowerRecordType(assertedType);
+}
+
+/** Detect immutable local bindings that erase a known type and are later asserted back to a narrower type. */
+export const noWidenThenAssertRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow local const flows that explicitly widen a known value before asserting the widened binding to a narrower type.",
+    },
+    messages: {
+      widenThenAssert:
+        'Binding "{{name}}" discards type evidence and later recreates it with an assertion. Keep the precise type from initialization through use; parse boundary input once.',
+    },
+  },
+  createOnce(context) {
+    let scopes: Parameters<typeof resolvedVariableForIdentifier>[0] = [];
+
+    const checkAssertion = (node: ESTree.TSAsExpression | ESTree.TSTypeAssertion) => {
+      const expression = assertedExpression(node);
+      if (expression.type !== "Identifier") return;
+
+      const variable = resolvedVariableForIdentifier(scopes, expression);
+      if (variable === null) return;
+      const widened = widenedBinding(variable, scopes);
+      if (
+        widened === null ||
+        node.start <= widened.declaredAt ||
+        functionBoundary(node) !== widened.boundary ||
+        !assertionIsNarrower(
+          context.sourceCode.text,
+          widened.broadKind,
+          widened.evidence,
+          node.typeAnnotation,
+        )
+      ) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: "widenThenAssert",
+        data: { name: expression.name },
+      });
+    };
+
+    return {
+      Program() {
+        scopes = context.sourceCode.scopeManager.scopes;
+      },
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
+++ b/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
@@ -1,0 +1,131 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+type TypeAssertion = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+const DEFAULT_SAFETY_MARKERS = ["SAFETY"] as const;
+
+const commentOwnerKinds = new Set([
+  "ExpressionStatement",
+  "PropertyDefinition",
+  "ReturnStatement",
+  "ThrowStatement",
+  "VariableDeclaration",
+]);
+
+function isConstAssertion(node: TypeAssertion): boolean {
+  return (
+    node.typeAnnotation.type === "TSTypeReference" &&
+    node.typeAnnotation.typeName.type === "Identifier" &&
+    node.typeAnnotation.typeName.name === "const"
+  );
+}
+
+function configuredSafetyMarkers(option: unknown): readonly string[] {
+  if (typeof option !== "object" || option === null || !("markers" in option)) {
+    return DEFAULT_SAFETY_MARKERS;
+  }
+  const configured = option.markers;
+  if (!Array.isArray(configured)) return DEFAULT_SAFETY_MARKERS;
+  const markers = configured.flatMap((marker) =>
+    typeof marker === "string" && marker.trim().length > 0 ? [marker.trim()] : [],
+  );
+  return markers.length > 0 ? markers : DEFAULT_SAFETY_MARKERS;
+}
+
+function markerPattern(markers: readonly string[]): RegExp {
+  const alternation = markers
+    .map((marker) => marker.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`))
+    .join("|");
+  return new RegExp(
+    String.raw`(?:^|[^\p{L}\p{N}_])(?:${alternation})\s*:\s*\S`,
+    "u",
+  );
+}
+
+function hasSafetyJustificationBefore(
+  sourceCode: SourceCode,
+  owner: ESTree.Node,
+  assertion: TypeAssertion,
+  pattern: RegExp,
+): boolean {
+  return sourceCode
+    .getCommentsBefore(owner)
+    .some(
+      (comment) => comment.end <= assertion.start && pattern.test(comment.value),
+    );
+}
+
+function hasSafetyComment(
+  sourceCode: SourceCode,
+  node: TypeAssertion,
+  pattern: RegExp,
+): boolean {
+  let current: ESTree.Node = node;
+  while (true) {
+    if (hasSafetyJustificationBefore(sourceCode, current, node, pattern)) return true;
+    if (commentOwnerKinds.has(current.type)) {
+      const exportDeclaration = current.parent;
+      return (
+        exportDeclaration.type === "ExportNamedDeclaration" &&
+        exportDeclaration.declaration === current &&
+        hasSafetyJustificationBefore(sourceCode, exportDeclaration, node, pattern)
+      );
+    }
+    if (current.parent.type === "Program") return false;
+    current = current.parent;
+  }
+}
+
+/** Require every non-const type assertion to state the invariant TypeScript cannot express. */
+export const requireSafetyCommentForTypeAssertionRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require a nearby SAFETY comment for every TypeScript type assertion except const assertions.",
+    },
+    messages: {
+      missingSafetyComment:
+        "This type assertion has no `{{marker}}:` justification. State the checked invariant immediately before the assertion or its containing statement.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          markers: {
+            type: "array",
+            items: { type: "string", minLength: 1 },
+            minItems: 1,
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    defaultOptions: [{ markers: ["SAFETY"] }],
+  },
+  createOnce(context) {
+    const patterns = new Map<string, RegExp>();
+
+    const checkAssertion = (node: TypeAssertion) => {
+      if (isConstAssertion(node)) return;
+      const markers = configuredSafetyMarkers(context.options?.[0]);
+      const patternKey = markers.join("\u0000");
+      const pattern = patterns.get(patternKey) ?? markerPattern(markers);
+      patterns.set(patternKey, pattern);
+      if (hasSafetyComment(context.sourceCode, node, pattern)) return;
+      context.report({
+        node,
+        messageId: "missingSafetyComment",
+        data: { marker: markers[0] ?? DEFAULT_SAFETY_MARKERS[0] },
+      });
+    };
+
+    return {
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/shared/dictionary-types.ts
+++ b/tools/oxlint/anti-slop/shared/dictionary-types.ts
@@ -1,0 +1,515 @@
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+	createTypeAliasEnvironment,
+	hasVisibleTypeBinding,
+	visibleTypeAlias,
+	type TypeAliasEnvironment as LexicalTypeAliasEnvironment,
+} from "./type-alias-resolution.ts";
+
+const BUILT_INS = new Set([
+	"Record",
+	"Readonly",
+	"Partial",
+	"Required",
+	"Pick",
+	"Omit",
+	"PropertyKey",
+	"NonNullable",
+]);
+const TRANSPARENT_WRAPPERS = new Set(["Readonly", "Partial", "Required", "NonNullable"]);
+
+type TypeAliasEnvironment = ReadonlyMap<string, ESTree.TSType>;
+
+type ResolvedType = {
+	readonly type: ESTree.TSType;
+	readonly substitutions: TypeAliasEnvironment;
+};
+
+export type UnsafeDictionary = {
+	readonly kind: "unsafe-dictionary";
+	readonly unsafeValue: "any" | "empty-object" | "object" | "union" | "unknown";
+};
+
+export type WideningTargetKind =
+	| "anonymous object"
+	| "generic container"
+	| "object"
+	| "open dictionary"
+	| "unknown";
+
+export type WideningTarget = {
+	readonly kind: WideningTargetKind;
+};
+
+export type TypeEnvironment = {
+	readonly interfaces: ReadonlyMap<string, readonly ESTree.TSInterfaceDeclaration[]>;
+	readonly typeAliases: LexicalTypeAliasEnvironment;
+};
+
+function declaredStatement(statement: ESTree.Statement): ESTree.Node | null {
+	return statement.type === "ExportNamedDeclaration" ||
+		statement.type === "ExportDefaultDeclaration"
+		? (statement.declaration ?? null)
+		: statement;
+}
+
+export function createTypeEnvironment(
+	program: ESTree.Program,
+	visitorKeys: Readonly<Record<string, readonly string[]>>,
+): TypeEnvironment {
+	const interfaces = new Map<string, ESTree.TSInterfaceDeclaration[]>();
+
+	for (const statement of program.body) {
+		const declaration = declaredStatement(statement);
+		if (declaration?.type !== "TSInterfaceDeclaration") continue;
+		const declarations = interfaces.get(declaration.id.name) ?? [];
+		declarations.push(declaration);
+		interfaces.set(declaration.id.name, declarations);
+	}
+
+	return {
+		interfaces,
+		typeAliases: createTypeAliasEnvironment(program, visitorKeys),
+	};
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isBuiltIn(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeEnvironment,
+): boolean {
+	return (
+		BUILT_INS.has(name) &&
+		!hasVisibleTypeBinding(name, use, environment.typeAliases)
+	);
+}
+
+function isUnappliedReferenceTo(type: ESTree.TSType, name: string): boolean {
+	const unwrapped = unwrapTransparentType(type);
+	return (
+		unwrapped.type === "TSTypeReference" &&
+		typeReferenceName(unwrapped) === name &&
+		(unwrapped.typeArguments === null ||
+			unwrapped.typeArguments === undefined ||
+			unwrapped.typeArguments.params.length === 0)
+	);
+}
+
+function unwrapTransparentType(type: ESTree.TSType): ESTree.TSType {
+	let current = type;
+	while (
+		current.type === "TSParenthesizedType" ||
+		(current.type === "TSTypeOperator" && current.operator === "readonly")
+	) {
+		current = current.typeAnnotation;
+	}
+	return current;
+}
+
+function isNeverType(type: ESTree.TSType): boolean {
+	return unwrapTransparentType(type).type === "TSNeverKeyword";
+}
+
+function isEffectivelyEmptyMember(member: ESTree.TSSignature): boolean {
+	return (
+		member.type === "TSPropertySignature" &&
+		member.optional === true &&
+		member.typeAnnotation !== null &&
+		member.typeAnnotation !== undefined &&
+		isNeverType(member.typeAnnotation.typeAnnotation)
+	);
+}
+
+function isEffectivelyEmptyTypeLiteral(type: ESTree.TSTypeLiteral): boolean {
+	return type.members.length === 0 || type.members.every(isEffectivelyEmptyMember);
+}
+
+function isEffectivelyEmptyInterface(
+	declarations: readonly ESTree.TSInterfaceDeclaration[],
+): boolean {
+	if (declarations.length !== 1) return false;
+	const [type] = declarations;
+	return (
+		type !== undefined &&
+		type.extends.length === 0 &&
+		(type.body.body.length === 0 || type.body.body.every(isEffectivelyEmptyMember))
+	);
+}
+
+function resolvedSubstitutionArgument(
+	type: ESTree.TSType,
+	base: TypeAliasEnvironment,
+	resolving: ReadonlySet<string> = new Set(),
+): ESTree.TSType {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type !== "TSTypeReference") return type;
+	const name = typeReferenceName(unwrapped);
+	if (name === null || resolving.has(name)) return type;
+	const substitution = base.get(name);
+	if (substitution === undefined) return type;
+	const nextResolving = new Set(resolving);
+	nextResolving.add(name);
+	return resolvedSubstitutionArgument(substitution, base, nextResolving);
+}
+
+function aliasSubstitution(
+	alias: ESTree.TSTypeAliasDeclaration,
+	type: ESTree.TSTypeReference,
+	base: TypeAliasEnvironment,
+): TypeAliasEnvironment | null {
+	const parameters = alias.typeParameters?.params ?? [];
+	const arguments_ = type.typeArguments?.params ?? [];
+	const next = new Map(base);
+	for (const [index, parameter] of parameters.entries()) {
+		const argument = arguments_[index] ?? parameter.default;
+		if (argument === null || argument === undefined) return null;
+		next.set(parameter.name.name, resolvedSubstitutionArgument(argument, next));
+	}
+	return next;
+}
+
+function unsafeDirectValue(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): UnsafeDictionary["unsafeValue"] | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return "unknown";
+	if (unwrapped.type === "TSAnyKeyword") return "any";
+	if (unwrapped.type === "TSObjectKeyword") return "object";
+	if (unwrapped.type === "TSTypeLiteral" && isEffectivelyEmptyTypeLiteral(unwrapped))
+		return "empty-object";
+	if (unwrapped.type === "TSUnionType") {
+		return unwrapped.types.some(
+			(member) => unsafeDirectValue(member, environment, substitutions, resolvingAliases) !== null,
+		)
+			? "union"
+			: null;
+	}
+	if (unwrapped.type === "TSIntersectionType") {
+		const unsafeMembers = unwrapped.types.map((member) =>
+			unsafeDirectValue(member, environment, substitutions, resolvingAliases),
+		);
+		if (unsafeMembers.includes("any")) return "any";
+		return unsafeMembers.length > 0 && unsafeMembers.every((member) => member !== null)
+			? (unsafeMembers[0] ?? null)
+			: null;
+	}
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? null
+			: unsafeDirectValue(wrapped, environment, substitutions, resolvingAliases);
+	}
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? null
+			: unsafeDirectValue(substitution, environment, substitutions, resolvingAliases);
+	}
+	const interfaceDeclarations = environment.interfaces.get(name);
+	if (interfaceDeclarations !== undefined) {
+		return isEffectivelyEmptyInterface(interfaceDeclarations) ? "empty-object" : null;
+	}
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null || resolvingAliases.has(name)) return null;
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return null;
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return unsafeDirectValue(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+function dictionaryValueTypes(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): readonly ResolvedType[] {
+	const unwrapped = unwrapTransparentType(type);
+
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.flatMap((member): readonly ResolvedType[] =>
+			member.type === "TSIndexSignature" && member.typeAnnotation !== null
+				? [{ type: member.typeAnnotation.typeAnnotation, substitutions }]
+				: [],
+		);
+	}
+
+	if (unwrapped.type === "TSMappedType") {
+		return unwrapped.typeAnnotation === null
+			? []
+			: [{ type: unwrapped.typeAnnotation, substitutions }];
+	}
+
+	if (unwrapped.type !== "TSTypeReference") return [];
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return [];
+
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? []
+			: dictionaryValueTypes(substitution, environment, substitutions, resolvingAliases);
+	}
+
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? []
+			: dictionaryValueTypes(wrapped, environment, substitutions, resolvingAliases);
+	}
+
+	if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+		const value = unwrapped.typeArguments?.params[1] ?? null;
+		return value === null ? [] : [{ type: value, substitutions }];
+	}
+
+	if (
+		(name === "Pick" || name === "Omit") &&
+		isBuiltIn(name, unwrapped, environment)
+	) {
+		const source = unwrapped.typeArguments?.params[0];
+		return source === undefined
+			? []
+			: dictionaryValueTypes(source, environment, substitutions, resolvingAliases);
+	}
+
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null || resolvingAliases.has(name)) return [];
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return [];
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return dictionaryValueTypes(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+export function classifyUnsafeDictionaryValue(
+	valueType: ESTree.TSType,
+	environment: TypeEnvironment,
+): UnsafeDictionary | null {
+	const unsafeValue = unsafeDirectValue(valueType, environment, new Map(), new Set());
+	return unsafeValue === null ? null : { kind: "unsafe-dictionary", unsafeValue };
+}
+
+export function classifyUnsafeDictionary(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): UnsafeDictionary | null {
+	for (const valueType of dictionaryValueTypes(type, environment, new Map(), new Set())) {
+		const unsafeValue = unsafeDirectValue(
+			valueType.type,
+			environment,
+			valueType.substitutions,
+			new Set(),
+		);
+		if (unsafeValue !== null) return { kind: "unsafe-dictionary", unsafeValue };
+	}
+	return null;
+}
+
+export function classifyWideningTarget(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): WideningTarget | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
+	if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+			? { kind: "open dictionary" }
+			: unwrapped.members.length > 0
+				? { kind: "anonymous object" }
+				: null;
+	}
+	if (unwrapped.type === "TSMappedType") return { kind: "open dictionary" };
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined ? null : classifyWideningTarget(wrapped, environment);
+	}
+	if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+		return hasBroadRecordKey(unwrapped, environment, new Map())
+			? { kind: "open dictionary" }
+			: null;
+	}
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null) return null;
+	if ((alias.typeParameters?.params.length ?? 0) > 0) {
+		const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+		const resolved =
+			substitutions === null
+				? null
+				: classifyAliasBroadTarget(
+						alias.typeAnnotation,
+						environment,
+						substitutions,
+						new Set([name]),
+					);
+		return resolved?.kind === "open dictionary" ? { kind: "generic container" } : null;
+	}
+	const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+	if (substitutions === null) return null;
+	const resolved = classifyAliasBroadTarget(
+		alias.typeAnnotation,
+		environment,
+		substitutions,
+		new Set([name]),
+	);
+	return resolved;
+}
+
+function hasBroadRecordKey(
+	type: ESTree.TSTypeReference,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+): boolean {
+	const key = type.typeArguments?.params[0];
+	return key === undefined || isBroadMappedKey(key, environment, substitutions);
+}
+
+function isBroadMappedKey(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	visitedAliases: ReadonlySet<string> = new Set(),
+): boolean {
+	const unwrapped = unwrapTransparentType(type);
+	if (
+		unwrapped.type === "TSStringKeyword" ||
+		unwrapped.type === "TSNumberKeyword" ||
+		unwrapped.type === "TSSymbolKeyword"
+	) {
+		return true;
+	}
+	if (unwrapped.type === "TSUnionType") {
+		return unwrapped.types.some((member) =>
+			isBroadMappedKey(member, environment, substitutions, visitedAliases),
+		);
+	}
+	if (unwrapped.type !== "TSTypeReference") return false;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return false;
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined && !isUnappliedReferenceTo(substitution, name)) {
+		return isBroadMappedKey(substitution, environment, substitutions, visitedAliases);
+	}
+	if (name === "PropertyKey" && isBuiltIn(name, unwrapped, environment)) return true;
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (
+		alias === null ||
+		(alias.typeParameters?.params.length ?? 0) > 0 ||
+		visitedAliases.has(name)
+	) {
+		return false;
+	}
+	const nextVisited = new Set(visitedAliases);
+	nextVisited.add(name);
+	return isBroadMappedKey(alias.typeAnnotation, environment, substitutions, nextVisited);
+}
+
+function classifyAliasBroadTarget(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): WideningTarget | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
+	if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+			? { kind: "open dictionary" }
+			: null;
+	}
+	if (unwrapped.type === "TSMappedType") {
+		return isBroadMappedKey(unwrapped.constraint, environment, substitutions)
+			? { kind: "open dictionary" }
+			: null;
+	}
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? null
+			: classifyAliasBroadTarget(
+					substitution,
+					environment,
+					substitutions,
+					resolvingAliases,
+				);
+	}
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? null
+			: classifyAliasBroadTarget(wrapped, environment, substitutions, resolvingAliases);
+	}
+	if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+		return hasBroadRecordKey(unwrapped, environment, substitutions)
+			? { kind: "open dictionary" }
+			: null;
+	}
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null || resolvingAliases.has(name)) return null;
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return null;
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return classifyAliasBroadTarget(
+		alias.typeAnnotation,
+		environment,
+		nextSubstitutions,
+		nextResolving,
+	);
+}
+
+export function isPopulatedObjectExpression(expression: ESTree.Expression): boolean {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression"
+	) {
+		current = current.expression;
+	}
+	return current.type === "ObjectExpression" && current.properties.length > 0;
+}
+
+export function isKnownEvidenceExpression(expression: ESTree.Expression): boolean {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression" ||
+		current.type === "TSSatisfiesExpression"
+	) {
+		current = current.expression;
+	}
+	if (current.type === "ObjectExpression") return true;
+	return (
+		current.type === "ArrayExpression" ||
+		current.type === "ArrowFunctionExpression" ||
+		current.type === "ClassExpression" ||
+		current.type === "FunctionExpression" ||
+		current.type === "NewExpression" ||
+		current.type === "Literal" ||
+		current.type === "TemplateLiteral" ||
+		current.type === "UnaryExpression"
+	);
+}

--- a/tools/oxlint/anti-slop/shared/function-parameters.ts
+++ b/tools/oxlint/anti-slop/shared/function-parameters.ts
@@ -1,0 +1,49 @@
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+export type FunctionParameter = ESTree.ParamPattern;
+
+/** Return whether a type is or contains TypeScript's absorbing unknown top type. */
+export function containsUnknownType(type: ESTree.TSType): boolean {
+	if (type.type === "TSUnknownKeyword") return true;
+	if (type.type === "TSParenthesizedType") return containsUnknownType(type.typeAnnotation);
+	return type.type === "TSUnionType" && type.types.some(containsUnknownType);
+}
+
+/** Return the TypeScript annotation attached to a function parameter or its wrapped binding. */
+export function functionParameterTypeAnnotation(
+	parameter: FunctionParameter,
+): ESTree.TSTypeAnnotation | null | undefined {
+	if (parameter.type === "TSParameterProperty") {
+		return functionParameterTypeAnnotation(parameter.parameter);
+	}
+	if (parameter.type === "RestElement") {
+		return parameter.typeAnnotation ?? functionParameterTypeAnnotation(parameter.argument);
+	}
+	if (parameter.type === "AssignmentPattern") {
+		return parameter.typeAnnotation ?? functionParameterTypeAnnotation(parameter.left);
+	}
+	return parameter.typeAnnotation;
+}
+
+/** Return only a function parameter's local binding, excluding its annotation and default value. */
+export function functionParameterBindingName(
+	parameter: FunctionParameter,
+	sourceCode: SourceCode,
+): string {
+	if (parameter.type === "TSParameterProperty") {
+		return functionParameterBindingName(parameter.parameter, sourceCode);
+	}
+	if (parameter.type === "AssignmentPattern") {
+		return functionParameterBindingName(parameter.left, sourceCode);
+	}
+	if (parameter.type === "RestElement") {
+		return functionParameterBindingName(parameter.argument, sourceCode);
+	}
+	if (parameter.type === "Identifier") return parameter.name;
+
+	const sourceText = sourceCode.getText(parameter);
+	const annotationStart = parameter.typeAnnotation?.start;
+	return annotationStart === undefined
+		? sourceText
+		: sourceText.slice(0, annotationStart - parameter.start).trimEnd();
+}

--- a/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
+++ b/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
@@ -1,0 +1,61 @@
+import type { ESTree } from "@oxlint/plugins";
+
+type VisitorKeys = Readonly<Record<string, readonly string[]>>;
+
+function isNode(value: unknown): value is ESTree.Node {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		typeof value.type === "string"
+	);
+}
+
+function collectInferTypeParameterNames(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+	names: Set<string>,
+): void {
+	if (node.type === "TSInferType") names.add(node.typeParameter.name.name);
+	const record = node as unknown as Readonly<Record<string, unknown>>;
+	for (const key of visitorKeys[node.type] ?? []) {
+		const value = record[key];
+		if (isNode(value)) {
+			collectInferTypeParameterNames(value, visitorKeys, names);
+			continue;
+		}
+		if (!Array.isArray(value)) continue;
+		for (const child of value) {
+			if (isNode(child)) collectInferTypeParameterNames(child, visitorKeys, names);
+		}
+	}
+}
+
+/** Collect type binders that are in scope at a node and can shadow module aliases. */
+export function lexicalTypeParameterNames(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+): ReadonlySet<string> {
+	const names = new Set<string>();
+	let descendant: ESTree.Node = node;
+	let current: ESTree.Node | null = node;
+	while (current !== null && current.type !== "Program") {
+		if ("typeParameters" in current) {
+			for (const parameter of current.typeParameters?.params ?? []) {
+				names.add(parameter.name.name);
+			}
+		}
+		if (
+			current.type === "TSMappedType" &&
+			(descendant === current.nameType || descendant === current.typeAnnotation)
+		) {
+			names.add(current.key.name);
+		}
+		if (current.type === "TSConditionalType" && descendant === current.trueType) {
+			collectInferTypeParameterNames(current.extendsType, visitorKeys, names);
+		}
+		descendant = current;
+		current = current.parent;
+	}
+	return names;
+}

--- a/tools/oxlint/anti-slop/shared/reflect-method.ts
+++ b/tools/oxlint/anti-slop/shared/reflect-method.ts
@@ -1,0 +1,35 @@
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function isGlobalReflect(sourceCode: SourceCode, expression: ESTree.Expression): boolean {
+  if (expression.type !== "Identifier" || expression.name !== "Reflect") return false;
+  if (sourceCode.isGlobalReference(expression)) return true;
+  const variable = resolveVariable(sourceCode, expression);
+  return variable === null || variable.defs.length === 0;
+}
+
+/** Reports whether a call target names one method on the global Reflect object. */
+export function isGlobalReflectMethodCall(
+  sourceCode: SourceCode,
+  callee: ESTree.Expression,
+  methodName: string,
+): boolean {
+  if (!("property" in callee) || !("object" in callee) || !("computed" in callee)) return false;
+  if (!isGlobalReflect(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  return callee.computed
+    ? property.type === "Literal" && property.value === methodName
+    : property.type === "Identifier" && property.name === methodName;
+}

--- a/tools/oxlint/anti-slop/shared/type-alias-resolution.ts
+++ b/tools/oxlint/anti-slop/shared/type-alias-resolution.ts
@@ -1,0 +1,250 @@
+import type { ESTree } from "@oxlint/plugins";
+
+import { lexicalTypeParameterNames } from "./lexical-type-parameters.ts";
+
+type VisitorKeys = Readonly<Record<string, readonly string[]>>;
+type TypeScope = ESTree.Node;
+
+type TypeBinding = {
+	readonly alias: ESTree.TSTypeAliasDeclaration | null;
+	readonly name: string;
+	readonly scope: TypeScope;
+};
+
+type Substitution = {
+	readonly substitutions: Substitutions;
+	readonly type: ESTree.TSType;
+};
+
+type Substitutions = ReadonlyMap<string, Substitution>;
+
+export type TypeAliasEnvironment = {
+	readonly aliases: readonly ESTree.TSTypeAliasDeclaration[];
+	readonly bindingsByName: ReadonlyMap<string, readonly TypeBinding[]>;
+	readonly visitorKeys: VisitorKeys;
+};
+
+export type ResolvedTypeMatcher = (
+	type: ESTree.TSType,
+	matches: (child: ESTree.TSType) => boolean,
+) => boolean;
+
+const environmentsByProgram = new WeakMap<ESTree.Program, TypeAliasEnvironment>();
+
+function isNode(value: unknown): value is ESTree.Node {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		typeof value.type === "string"
+	);
+}
+
+function enclosingTypeScope(node: ESTree.Node): TypeScope {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null) {
+		if (
+			current.type === "Program" ||
+			current.type === "BlockStatement" ||
+			current.type === "TSModuleBlock" ||
+			current.type === "StaticBlock" ||
+			current.type === "SwitchStatement"
+		) {
+			return current;
+		}
+		current = current.parent;
+	}
+	return node;
+}
+
+function declaredTypeBinding(node: ESTree.Node): {
+	readonly alias: ESTree.TSTypeAliasDeclaration | null;
+	readonly name: string;
+} | null {
+	if (node.type === "TSTypeAliasDeclaration") {
+		return { alias: node, name: node.id.name };
+	}
+	if (
+		node.type === "TSInterfaceDeclaration" ||
+		node.type === "TSEnumDeclaration" ||
+		node.type === "ClassDeclaration" ||
+		node.type === "ClassExpression"
+	) {
+		return node.id === null ? null : { alias: null, name: node.id.name };
+	}
+	if (
+		node.type === "ImportSpecifier" ||
+		node.type === "ImportDefaultSpecifier" ||
+		node.type === "ImportNamespaceSpecifier"
+	) {
+		return { alias: null, name: node.local.name };
+	}
+	return null;
+}
+
+function collectTypeBindings(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+	bindingsByName: Map<string, TypeBinding[]>,
+	aliases: ESTree.TSTypeAliasDeclaration[],
+): void {
+	const declared = declaredTypeBinding(node);
+	if (declared !== null) {
+		const bindings = bindingsByName.get(declared.name) ?? [];
+		bindings.push({ ...declared, scope: enclosingTypeScope(node) });
+		bindingsByName.set(declared.name, bindings);
+		if (declared.alias !== null) aliases.push(declared.alias);
+	}
+
+	// SAFETY: Oxlint's visitor keys identify only ESTree child-node properties.
+	const fields = node as unknown as Readonly<Record<string, unknown>>;
+	for (const key of visitorKeys[node.type] ?? []) {
+		const value = fields[key];
+		if (isNode(value)) {
+			collectTypeBindings(value, visitorKeys, bindingsByName, aliases);
+			continue;
+		}
+		if (!Array.isArray(value)) continue;
+		for (const child of value) {
+			if (isNode(child)) {
+				collectTypeBindings(child, visitorKeys, bindingsByName, aliases);
+			}
+		}
+	}
+}
+
+/** Collect every lexical type alias and competing type binding in a program. */
+export function createTypeAliasEnvironment(
+	program: ESTree.Program,
+	visitorKeys: VisitorKeys,
+): TypeAliasEnvironment {
+	const cached = environmentsByProgram.get(program);
+	if (cached !== undefined) return cached;
+	const bindingsByName = new Map<string, TypeBinding[]>();
+	const aliases: ESTree.TSTypeAliasDeclaration[] = [];
+	collectTypeBindings(program, visitorKeys, bindingsByName, aliases);
+	const environment = { aliases, bindingsByName, visitorKeys };
+	environmentsByProgram.set(program, environment);
+	return environment;
+}
+
+function ancestorDistance(ancestor: ESTree.Node, node: ESTree.Node): number | null {
+	let current: ESTree.Node | null = node;
+	let distance = 0;
+	while (current !== null) {
+		if (current === ancestor) return distance;
+		current = current.parent;
+		distance += 1;
+	}
+	return null;
+}
+
+function nearestTypeBindings(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeAliasEnvironment,
+): readonly TypeBinding[] {
+	const candidates = environment.bindingsByName.get(name) ?? [];
+	let nearestDistance = Number.POSITIVE_INFINITY;
+	let nearest: TypeBinding[] = [];
+	for (const candidate of candidates) {
+		const distance = ancestorDistance(candidate.scope, use);
+		if (distance === null || distance > nearestDistance) continue;
+		if (distance === nearestDistance) {
+			nearest.push(candidate);
+			continue;
+		}
+		nearestDistance = distance;
+		nearest = [candidate];
+	}
+	return nearest;
+}
+
+/** Resolve the nearest visible alias with this name, respecting lexical shadowing. */
+export function visibleTypeAlias(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeAliasEnvironment,
+): ESTree.TSTypeAliasDeclaration | null {
+	if (lexicalTypeParameterNames(use, environment.visitorKeys).has(name)) return null;
+	const bindings = nearestTypeBindings(name, use, environment);
+	return bindings.length === 1 ? (bindings[0]?.alias ?? null) : null;
+}
+
+/** Return whether a local declaration shadows a built-in type at this use. */
+export function hasVisibleTypeBinding(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeAliasEnvironment,
+): boolean {
+	return (
+		lexicalTypeParameterNames(use, environment.visitorKeys).has(name) ||
+		nearestTypeBindings(name, use, environment).length > 0
+	);
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function aliasSubstitutions(
+	alias: ESTree.TSTypeAliasDeclaration,
+	reference: ESTree.TSTypeReference,
+	base: Substitutions,
+): Substitutions | null {
+	const parameters = alias.typeParameters?.params ?? [];
+	const arguments_ = reference.typeArguments?.params ?? [];
+	const next = new Map(base);
+	for (const [index, parameter] of parameters.entries()) {
+		const explicitArgument = arguments_[index];
+		const argument = explicitArgument ?? parameter.default;
+		if (argument === null || argument === undefined) return null;
+		const argumentSubstitutions = explicitArgument === undefined ? next : base;
+		next.set(parameter.name.name, {
+			type: argument,
+			substitutions: new Map(argumentSubstitutions),
+		});
+	}
+	return next;
+}
+
+/** Match a type after resolving visible aliases and substituting their type parameters. */
+export function resolvedTypeMatches(
+	type: ESTree.TSType,
+	environment: TypeAliasEnvironment,
+	matcher: ResolvedTypeMatcher,
+): boolean {
+	const evaluate = (
+		current: ESTree.TSType,
+		substitutions: Substitutions,
+		resolvingAliases: ReadonlySet<ESTree.TSTypeAliasDeclaration>,
+	): boolean => {
+		if (current.type === "TSTypeReference") {
+			const name = typeReferenceName(current);
+			if (name !== null) {
+				const substitution = substitutions.get(name);
+				if (substitution !== undefined && !current.typeArguments?.params.length) {
+					return evaluate(
+						substitution.type,
+						substitution.substitutions,
+						resolvingAliases,
+					);
+				}
+				const alias = visibleTypeAlias(name, current, environment);
+				if (alias !== null && !resolvingAliases.has(alias)) {
+					const nextSubstitutions = aliasSubstitutions(alias, current, substitutions);
+					if (nextSubstitutions !== null) {
+						const nextResolving = new Set(resolvingAliases);
+						nextResolving.add(alias);
+						return evaluate(alias.typeAnnotation, nextSubstitutions, nextResolving);
+					}
+				}
+			}
+		}
+		return matcher(current, (child) =>
+			evaluate(child, substitutions, resolvingAliases),
+		);
+	};
+
+	return evaluate(type, new Map(), new Set());
+}

--- a/tools/oxlint/automation/README.md
+++ b/tools/oxlint/automation/README.md
@@ -1,0 +1,48 @@
+# Automation Oxlint rules
+
+Selected rule sources copied from [typeonce-dev/ai-automation](https://github.com/typeonce-dev/ai-automation/tree/0bca096fe6fe9878cd15303a623dd2cd85915ddd/rules/oxlint)
+at commit `0bca096fe6fe9878cd15303a623dd2cd85915ddd`.
+No skill, typed-lint engine, or other automation scripts are installed.
+
+The 22 rules registered in `index.ts` are enabled as errors in `.oxlintrc.json`.
+They cover unsafe casts, Effect composition and capabilities, validation,
+error handling, and component-local functions. Upstream rule implementations
+are unchanged; the entry point registers only the selected rules. Upstream's
+application-specific built-in policy and Tailwind dependencies are not copied.
+
+## Exclusions
+
+These policies are deliberately omitted to preserve this library's conventions
+and API. They are not suppressed globally through lint-disable comments.
+
+| Rules | Reason |
+| --- | --- |
+| `no-comments` | Comments and API documentation are encouraged; anti-slop also requires safety comments for assertions. |
+| `no-multiple-function-params`, `no-optional-function-parameters` | Positional, optional, and dual/pipeable arguments are part of the public API and Effect conventions. |
+| `private-function-prefix`, `no-single-use-private-functions` | Underscore naming and mandatory inlining conflict with the existing domain names and focused helpers. |
+| `no-type-assertion` | Anti-slop's safety-comment rule allows justified generic API and mock-stream assertions; `no-banned-type-assertions` still forbids casts to any, unknown, or never. |
+| `no-service-option` | Reusing an existing Progress, Renderer, or stdio service before providing defaults is intentional and tested. |
+| `require-context-service-in-services` | The services tree also owns renderer hooks, components, and pure store helpers, not just service declarations. |
+| `no-react-state-hooks` | Renderer clocks use local React state; the library does not use XState. |
+| `no-react-non-component-function-exports` | Column factories return JSX and are intentionally exported alongside rendering helpers. |
+| `no-reexport-only-modules` | `src/index.ts` is the package's public entry point. |
+| `no-api-backend-imports`, `no-api-repository-imports`, `require-tsx-in-ui-folders` | This terminal library has no application contract/repository or web UI folder architecture. |
+| All `xstate` and `next-tailwind` profile rules | Those frameworks and their architecture assumptions are absent. |
+
+## Narrow overrides
+
+- `use-now-clock.ts` and `use-spinner-clock.ts` may read `Date.now()` because
+  they own the React timer boundary. Randomness remains prohibited there.
+- `examples/benchmarks.ts` may serialize its own measurements with
+  `JSON.stringify`; it does not parse external JSON. The rule stays enabled
+  for the rest of the project.
+
+## Maintenance
+
+Copy selected files from upstream `rules/oxlint/src/rules/`, then update the
+source commit above. Keep `index.ts`, `.oxlintrc.json`, and this exclusion list
+in sync. Run `bun run check` and `bun test` after changes.
+
+Vendored rules are excluded from linting and formatting so each ruleset does
+not lint the other's implementation conventions. They remain typechecked,
+and their entry points are registered with Knip for dependency analysis.

--- a/tools/oxlint/automation/index.ts
+++ b/tools/oxlint/automation/index.ts
@@ -1,0 +1,50 @@
+import noBannedTypeAssertions from "./rules/no-banned-type-assertions.ts";
+import noAmbientNondeterminism from "./rules/no-ambient-nondeterminism.ts";
+import noCascadingLayerProvide from "./rules/no-cascading-layer-provide.ts";
+import noDirectBrowserStorage from "./rules/no-direct-browser-storage.ts";
+import noDirectFetch from "./rules/no-direct-fetch.ts";
+import noDisableValidation from "./rules/no-disable-validation.ts";
+import noEffectAsvoid from "./rules/no-effect-asvoid.ts";
+import noGlobalJson from "./rules/no-global-json.ts";
+import noInOperator from "./rules/no-in-operator.ts";
+import noNestedEffectArrayMethods from "./rules/no-nested-effect-array-methods.ts";
+import noNestedLayerProvide from "./rules/no-nested-layer-provide.ts";
+import noShadowedStandardArrayStatic from "./rules/no-shadowed-standard-array-static.ts";
+import noSilentErrorSwallow from "./rules/no-silent-error-swallow.ts";
+import noStaticEffectServiceForwarders from "./rules/no-static-effect-service-forwarders.ts";
+import noSwitch from "./rules/no-switch.ts";
+import noTryCatch from "./rules/no-try-catch.ts";
+import noTypeofObject from "./rules/no-typeof-object.ts";
+import pipeMaxArguments from "./rules/pipe-max-arguments.ts";
+import preferEffectMatch from "./rules/prefer-effect-match.ts";
+import preferOptionFromNullable from "./rules/prefer-option-from-nullable.ts";
+import noReactComponentInnerFunctions from "./rules/no-react-component-inner-functions.ts";
+import noSqlTypeParameter from "./rules/no-sql-type-parameter.ts";
+
+export default {
+  meta: { name: "automation" },
+  rules: {
+    "no-banned-type-assertions": noBannedTypeAssertions,
+    "no-ambient-nondeterminism": noAmbientNondeterminism,
+    "no-cascading-layer-provide": noCascadingLayerProvide,
+    "no-direct-browser-storage": noDirectBrowserStorage,
+    "no-direct-fetch": noDirectFetch,
+    "no-disable-validation": noDisableValidation,
+    "no-effect-asvoid": noEffectAsvoid,
+    "no-global-json": noGlobalJson,
+    "no-in-operator": noInOperator,
+    "no-nested-effect-array-methods": noNestedEffectArrayMethods,
+    "no-nested-layer-provide": noNestedLayerProvide,
+    "no-shadowed-standard-array-static": noShadowedStandardArrayStatic,
+    "no-silent-error-swallow": noSilentErrorSwallow,
+    "no-static-effect-service-forwarders": noStaticEffectServiceForwarders,
+    "no-switch": noSwitch,
+    "no-try-catch": noTryCatch,
+    "no-typeof-object": noTypeofObject,
+    "pipe-max-arguments": pipeMaxArguments,
+    "prefer-effect-match": preferEffectMatch,
+    "prefer-option-from-nullable": preferOptionFromNullable,
+    "no-react-component-inner-functions": noReactComponentInnerFunctions,
+    "no-sql-type-parameter": noSqlTypeParameter,
+  },
+};

--- a/tools/oxlint/automation/rules/no-ambient-nondeterminism.ts
+++ b/tools/oxlint/automation/rules/no-ambient-nondeterminism.ts
@@ -1,0 +1,205 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+type VisitorObject = ReturnType<NonNullable<Rule["create"]>>;
+type MemberExpressionNode = Parameters<
+  NonNullable<VisitorObject["MemberExpression"]>
+>[0];
+type IdentifierNode = Parameters<NonNullable<VisitorObject["Identifier"]>>[0];
+
+interface Options {
+  readonly allowedDateBasenames?: ReadonlyArray<string>;
+  readonly allowedDateExtensions?: ReadonlyArray<string>;
+}
+
+const _memberPropertyName = ({ node }: { node: MemberExpressionNode }) =>
+  node.property.type === "Identifier"
+    ? node.property.name
+    : node.property.type === "Literal" &&
+        typeof node.property.value === "string"
+      ? node.property.value
+      : undefined;
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Disallow ambient randomness and time in favor of Effect capabilities.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowedDateBasenames: {
+            type: "array",
+            items: { type: "string" },
+          },
+          allowedDateExtensions: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const options = (context.options[0] ?? {}) as Options;
+    const allowedDateBasenames = new Set(options.allowedDateBasenames ?? []);
+    const allowedDateExtensions = options.allowedDateExtensions ?? [".tsx"];
+    const filename = (context.filename ?? "").replaceAll("\\", "/");
+    const basename = filename.slice(filename.lastIndexOf("/") + 1);
+    const allowAmbientDate =
+      allowedDateExtensions.some((extension) => filename.endsWith(extension)) ||
+      allowedDateBasenames.has(basename);
+
+    const isGlobalIdentifier = ({
+      name,
+      node,
+    }: {
+      name: string;
+      node: IdentifierNode;
+    }) => {
+      if (node.name !== name) {
+        return false;
+      }
+
+      let scope: ReturnType<typeof context.sourceCode.getScope> | null =
+        context.sourceCode.getScope(node);
+
+      while (scope !== null) {
+        const variable = scope.set.get(name);
+
+        if (variable !== undefined) {
+          return variable.defs.length === 0;
+        }
+
+        scope = scope.upper;
+      }
+
+      return true;
+    };
+
+    const isGlobalThisMember = ({
+      name,
+      node,
+    }: {
+      name: string;
+      node: MemberExpressionNode;
+    }) =>
+      node.object.type === "Identifier" &&
+      isGlobalIdentifier({ name: "globalThis", node: node.object }) &&
+      _memberPropertyName({ node }) === name;
+
+    const isGlobalObject = ({
+      name,
+      node,
+    }: {
+      name: string;
+      node: MemberExpressionNode["object"];
+    }) =>
+      (node.type === "Identifier" &&
+        isGlobalIdentifier({
+          name,
+          node,
+        })) ||
+      (node.type === "MemberExpression" &&
+        isGlobalThisMember({
+          name,
+          node,
+        }));
+
+    return {
+      CallExpression(node) {
+        if (
+          allowAmbientDate ||
+          node.arguments.length !== 0 ||
+          node.callee.type !== "Identifier" ||
+          !isGlobalIdentifier({ name: "Date", node: node.callee })
+        ) {
+          return;
+        }
+
+        context.report({
+          node,
+          message:
+            "Do not read the current time from ambient Date. Use Effect Clock or DateTime capabilities.",
+        });
+      },
+      Identifier(node) {
+        if (
+          node.parent?.type === "MemberExpression" &&
+          node.parent.property === node &&
+          node.parent.computed !== true
+        ) {
+          return;
+        }
+
+        if (!isGlobalIdentifier({ name: "crypto", node })) {
+          return;
+        }
+
+        context.report({
+          node,
+          message:
+            "Do not use ambient crypto. Use Effect's Crypto capability instead.",
+        });
+      },
+      MemberExpression(node) {
+        const propertyName = _memberPropertyName({ node });
+
+        if (isGlobalThisMember({ name: "crypto", node })) {
+          context.report({
+            node,
+            message:
+              "Do not use ambient crypto. Use Effect's Crypto capability instead.",
+          });
+          return;
+        }
+
+        if (
+          propertyName === "random" &&
+          isGlobalObject({ name: "Math", node: node.object })
+        ) {
+          context.report({
+            node,
+            message:
+              "Do not use ambient Math.random. Use Effect's Random capability instead.",
+          });
+          return;
+        }
+
+        if (
+          !allowAmbientDate &&
+          propertyName === "now" &&
+          isGlobalObject({ name: "Date", node: node.object })
+        ) {
+          context.report({
+            node,
+            message:
+              "Do not read the current time from ambient Date. Use Effect Clock or DateTime capabilities.",
+          });
+        }
+      },
+      NewExpression(node) {
+        if (
+          allowAmbientDate ||
+          node.arguments.length !== 0 ||
+          node.callee.type !== "Identifier" ||
+          !isGlobalIdentifier({ name: "Date", node: node.callee })
+        ) {
+          return;
+        }
+
+        context.report({
+          node,
+          message:
+            "Do not read the current time from ambient Date. Use Effect Clock or DateTime capabilities.",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-banned-type-assertions.ts
+++ b/tools/oxlint/automation/rules/no-banned-type-assertions.ts
@@ -1,0 +1,44 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+const bannedTypes = new Set([
+  "TSAnyKeyword",
+  "TSNeverKeyword",
+  "TSUnknownKeyword",
+]);
+
+const message =
+  "Do not assert to any, never, or unknown. Fix the type or use generics.";
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Disallow assertions to any, never, or unknown; fix the type or use generics.",
+    },
+  },
+  create(context) {
+    return {
+      TSAsExpression(node) {
+        if (bannedTypes.has(node.typeAnnotation.type)) {
+          context.report({
+            node,
+            message,
+          });
+        }
+      },
+      TSTypeAssertion(node) {
+        if (bannedTypes.has(node.typeAnnotation.type)) {
+          context.report({
+            node,
+            message,
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-cascading-layer-provide.ts
+++ b/tools/oxlint/automation/rules/no-cascading-layer-provide.ts
@@ -1,0 +1,111 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+type VisitorObject = ReturnType<NonNullable<Rule["create"]>>;
+type CallExpressionNode = Parameters<
+  NonNullable<VisitorObject["CallExpression"]>
+>[0];
+type IdentifierNode = Extract<
+  CallExpressionNode["callee"],
+  { type: "Identifier" }
+>;
+
+const provisioningMethods = new Set(["provide", "provideMerge"]);
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Combine independent Layer dependencies in one provide call and extract intentional dependency stages.",
+    },
+  },
+  create(context) {
+    const findImportDefinition = ({ node }: { node: IdentifierNode }) => {
+      let scope: ReturnType<typeof context.sourceCode.getScope> | null =
+        context.sourceCode.getScope(node);
+
+      while (scope !== null) {
+        const variable = scope.set.get(node.name);
+
+        if (variable !== undefined) {
+          return variable.defs.find(
+            (definition) =>
+              definition.type === "ImportBinding" &&
+              definition.parent?.type === "ImportDeclaration"
+          );
+        }
+
+        scope = scope.upper;
+      }
+
+      return undefined;
+    };
+
+    const isEffectLayerIdentifier = ({ node }: { node: IdentifierNode }) => {
+      const definition = findImportDefinition({ node });
+
+      return (
+        definition?.parent?.type === "ImportDeclaration" &&
+        definition.parent.source.value === "effect" &&
+        definition.node.type === "ImportSpecifier" &&
+        (definition.node.imported.type === "Identifier"
+          ? definition.node.imported.name
+          : definition.node.imported.value) === "Layer"
+      );
+    };
+
+    const isLayerProvision = ({
+      node,
+    }: {
+      node: CallExpressionNode["arguments"][number];
+    }) => {
+      if (
+        node.type !== "CallExpression" ||
+        node.callee.type !== "MemberExpression" ||
+        node.callee.object.type !== "Identifier" ||
+        !isEffectLayerIdentifier({ node: node.callee.object })
+      ) {
+        return false;
+      }
+
+      const property = node.callee.property;
+      const propertyName =
+        property.type === "Identifier"
+          ? property.name
+          : property.type === "Literal" && typeof property.value === "string"
+            ? property.value
+            : undefined;
+
+      return provisioningMethods.has(propertyName ?? "");
+    };
+
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type !== "MemberExpression" ||
+          node.callee.property.type !== "Identifier" ||
+          node.callee.property.name !== "pipe"
+        ) {
+          return;
+        }
+
+        const provisioningStages = node.arguments.filter((argument) =>
+          isLayerProvision({ node: argument })
+        );
+
+        if (provisioningStages.length < 2) {
+          return;
+        }
+
+        context.report({
+          node,
+          message:
+            "Avoid multiple Layer.provide or Layer.provideMerge stages in one pipe. Combine independent dependencies in one Layer.provide([...]); when a layer depends on another layer, extract and name that configured layer before providing it.",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-direct-browser-storage.ts
+++ b/tools/oxlint/automation/rules/no-direct-browser-storage.ts
@@ -1,0 +1,116 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+type Node = {
+  [key: string]: unknown;
+  type: string;
+};
+
+const bannedBrowserStorageNames = new Set([
+  "indexedDB",
+  "localStorage",
+  "sessionStorage",
+]);
+
+const isNode = (value: unknown): value is Node =>
+  typeof value === "object" &&
+  value !== null &&
+  "type" in value &&
+  typeof value.type === "string";
+
+const getStorageIdentifierName = (node: unknown) =>
+  isNode(node) &&
+  node.type === "Identifier" &&
+  typeof node.name === "string" &&
+  bannedBrowserStorageNames.has(node.name)
+    ? node.name
+    : undefined;
+
+const messageFor = ({ name }: { name: string }) =>
+  `Do not use ${name} directly. Use Effect's IndexedDb or KeyValueStore modules instead.`;
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Disallow direct browser storage APIs in favor of Effect storage modules.",
+    },
+  },
+  create(context) {
+    return {
+      Identifier(node) {
+        const storageName = getStorageIdentifierName(node);
+
+        if (storageName === undefined) {
+          return;
+        }
+
+        const parent = isNode(node.parent) ? node.parent : undefined;
+
+        if (
+          (parent?.type === "Property" &&
+            parent.key === node &&
+            (!isNode(parent.parent) ||
+              parent.parent.type !== "ObjectPattern") &&
+            parent.value !== node) ||
+          (parent?.type === "MemberExpression" &&
+            parent.property === node &&
+            parent.computed !== true) ||
+          (parent?.type === "ImportSpecifier" &&
+            parent.imported === node &&
+            parent.local !== node) ||
+          (parent?.type === "MemberExpression" && parent.object === node)
+        ) {
+          return;
+        }
+
+        context.report({
+          node,
+          message: messageFor({ name: storageName }),
+        });
+      },
+      MemberExpression(node) {
+        const storageName =
+          node.object.type === "Identifier"
+            ? getStorageIdentifierName(node.object)
+            : undefined;
+
+        if (storageName !== undefined) {
+          context.report({
+            node,
+            message: messageFor({ name: storageName }),
+          });
+          return;
+        }
+
+        if (
+          node.object.type === "Identifier" &&
+          (node.object.name === "globalThis" || node.object.name === "window")
+        ) {
+          const propertyName =
+            node.property.type === "Identifier"
+              ? node.property.name
+              : node.property.type === "Literal" &&
+                  typeof node.property.value === "string"
+                ? node.property.value
+                : undefined;
+
+          if (!bannedBrowserStorageNames.has(propertyName ?? "")) {
+            return;
+          }
+
+          context.report({
+            node,
+            message: messageFor({
+              name: propertyName ?? "",
+            }),
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-direct-fetch.ts
+++ b/tools/oxlint/automation/rules/no-direct-fetch.ts
@@ -1,0 +1,47 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+const message =
+  "Do not call fetch directly. Use the existing API client or runtime client service.";
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Avoid direct fetch calls; use the existing API client or runtime client service.",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const callee = node.callee;
+
+        if (callee.type === "Identifier" && callee.name === "fetch") {
+          context.report({
+            node,
+            message,
+          });
+          return;
+        }
+
+        if (
+          callee.type === "MemberExpression" &&
+          callee.property.type === "Identifier" &&
+          callee.property.name === "fetch" &&
+          callee.object.type === "Identifier" &&
+          (callee.object.name === "window" ||
+            callee.object.name === "globalThis")
+        ) {
+          context.report({
+            node,
+            message,
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-disable-validation.ts
+++ b/tools/oxlint/automation/rules/no-disable-validation.ts
@@ -1,0 +1,54 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+type Node = {
+  [key: string]: unknown;
+  type: string;
+};
+
+const isNode = (value: unknown): value is Node =>
+  typeof value === "object" &&
+  value !== null &&
+  "type" in value &&
+  typeof value.type === "string";
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Keep Effect Schema validation enabled; fix the data or schema instead.",
+    },
+  },
+  create(context) {
+    return {
+      Property(node) {
+        const keyName = isNode(node.key)
+          ? node.key.type === "Identifier" ||
+            node.key.type === "PrivateIdentifier"
+            ? node.key.name
+            : node.key.type === "Literal"
+              ? node.key.value
+              : undefined
+          : undefined;
+        const value = node.value;
+
+        if (
+          keyName === "disableValidation" &&
+          isNode(value) &&
+          value.type === "Literal" &&
+          value.value === true
+        ) {
+          context.report({
+            node,
+            message:
+              "Do not use disableValidation: true. Fix the data or schema and keep validation enabled.",
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-effect-asvoid.ts
+++ b/tools/oxlint/automation/rules/no-effect-asvoid.ts
@@ -1,0 +1,35 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+const message =
+  "Avoid Effect.asVoid. Prefer returning the effect directly when the success type is void.";
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Avoid Effect.asVoid; return effects whose success type is already void directly.",
+    },
+  },
+  create(context) {
+    return {
+      MemberExpression(node) {
+        if (
+          node.object.type === "Identifier" &&
+          node.object.name === "Effect" &&
+          node.property.type === "Identifier" &&
+          node.property.name === "asVoid"
+        ) {
+          context.report({
+            node,
+            message,
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-global-json.ts
+++ b/tools/oxlint/automation/rules/no-global-json.ts
@@ -1,0 +1,72 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+type Node = {
+  readonly [key: string]: unknown;
+  readonly type: string;
+};
+
+const message =
+  "Do not use the global JSON API. Use Effect Schema encode/decode APIs instead.";
+
+const _isNode = (value: unknown): value is Node =>
+  typeof value === "object" &&
+  value !== null &&
+  Object.hasOwn(value, "type") &&
+  typeof Reflect.get(value, "type") === "string";
+
+const _nodeField = ({ field, node }: { field: string; node: Node }) =>
+  node[field];
+
+const _isIdentifier = ({ name, node }: { name: string; node: unknown }) =>
+  _isNode(node) &&
+  node.type === "Identifier" &&
+  _nodeField({ field: "name", node }) === name;
+
+const _isGlobalJson = (node: unknown): boolean => {
+  if (_isIdentifier({ name: "JSON", node })) {
+    return true;
+  }
+
+  if (!_isNode(node) || node.type !== "MemberExpression") {
+    return false;
+  }
+
+  return (
+    _isIdentifier({
+      name: "globalThis",
+      node: _nodeField({ field: "object", node }),
+    }) &&
+    _isIdentifier({
+      name: "JSON",
+      node: _nodeField({ field: "property", node }),
+    })
+  );
+};
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Avoid global JSON APIs; encode and decode JSON with Effect Schema.",
+    },
+  },
+  create(context) {
+    return {
+      MemberExpression(node) {
+        if (!_isGlobalJson(node.object)) {
+          return;
+        }
+
+        context.report({
+          node,
+          message,
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-in-operator.ts
+++ b/tools/oxlint/automation/rules/no-in-operator.ts
@@ -1,0 +1,30 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Avoid object key checks with the in operator; refactor the check or use Predicate as a last resort.",
+    },
+  },
+  create(context) {
+    return {
+      BinaryExpression(node) {
+        if (node.operator !== "in") {
+          return;
+        }
+
+        context.report({
+          node,
+          message:
+            'Do not use the "in" operator to check for object keys. Fix or refactor the code so this key check is not needed. Only use Predicate as a last-resort escape hatch.',
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-nested-effect-array-methods.ts
+++ b/tools/oxlint/automation/rules/no-nested-effect-array-methods.ts
@@ -1,0 +1,128 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+type Node = {
+  [key: string]: unknown;
+  type: string;
+};
+
+const ignoredKeys = new Set(["parent"]);
+
+const isNode = (value: unknown): value is Node =>
+  typeof value === "object" &&
+  value !== null &&
+  "type" in value &&
+  typeof value.type === "string";
+
+const nodeName = ({ value }: { value: unknown }) =>
+  isNode(value) && typeof value.name === "string" ? value.name : undefined;
+
+const isEffectArrayCall = ({ node }: { node: unknown }) =>
+  isNode(node) &&
+  node.type === "CallExpression" &&
+  isNode(node.callee) &&
+  node.callee.type === "MemberExpression" &&
+  isNode(node.callee.object) &&
+  isNode(node.callee.property) &&
+  node.callee.object.type === "Identifier" &&
+  node.callee.object.name === "Array" &&
+  node.callee.property.type === "Identifier";
+
+const containsEffectArrayCall = ({
+  node,
+  seen,
+}: {
+  node: unknown;
+  seen: WeakSet<object>;
+}): boolean => {
+  if (node === null || typeof node !== "object") {
+    return false;
+  }
+
+  if (seen.has(node)) {
+    return false;
+  }
+
+  seen.add(node);
+
+  if (isEffectArrayCall({ node })) {
+    return true;
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (ignoredKeys.has(key)) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      if (value.some((item) => containsEffectArrayCall({ node: item, seen }))) {
+        return true;
+      }
+
+      continue;
+    }
+
+    if (containsEffectArrayCall({ node: value, seen })) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Avoid nested Effect Array method calls; compose them with pipe to preserve inference.",
+    },
+  },
+  create(context) {
+    let arrayImportedFromEffect = false;
+
+    return {
+      ImportDeclaration(node) {
+        if (
+          isNode(node) &&
+          isNode(node.source) &&
+          node.source.value === "effect" &&
+          Array.isArray(node.specifiers) &&
+          node.specifiers
+            .filter(isNode)
+            .some(
+              (specifier) =>
+                specifier.type === "ImportSpecifier" &&
+                nodeName({ value: specifier.imported }) === "Array" &&
+                nodeName({ value: specifier.local }) === "Array"
+            )
+        ) {
+          arrayImportedFromEffect = true;
+        }
+      },
+      CallExpression(node) {
+        if (!arrayImportedFromEffect || !isEffectArrayCall({ node })) {
+          return;
+        }
+
+        if (
+          node.arguments.some((argument) =>
+            containsEffectArrayCall({
+              node: argument,
+              seen: new WeakSet<object>(),
+            })
+          )
+        ) {
+          context.report({
+            node,
+            message:
+              "Do not nest Effect Array method calls. Use pipe to preserve inference.",
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-nested-layer-provide.ts
+++ b/tools/oxlint/automation/rules/no-nested-layer-provide.ts
@@ -1,0 +1,57 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+type Node = {
+  [key: string]: unknown;
+  type: string;
+};
+
+const isNode = (value: unknown): value is Node =>
+  typeof value === "object" &&
+  value !== null &&
+  "type" in value &&
+  typeof value.type === "string";
+
+const isLayerProvide = (node: unknown) =>
+  isNode(node) &&
+  node.type === "CallExpression" &&
+  isNode(node.callee) &&
+  node.callee.type === "MemberExpression" &&
+  isNode(node.callee.object) &&
+  isNode(node.callee.property) &&
+  node.callee.object.type === "Identifier" &&
+  node.callee.object.name === "Layer" &&
+  node.callee.property.type === "Identifier" &&
+  node.callee.property.name === "provide";
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Avoid nested Layer.provide calls; extract the inner layer or use Layer.provideMerge.",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!isLayerProvide(node)) {
+          return;
+        }
+
+        for (const argument of node.arguments) {
+          if (isLayerProvide(argument)) {
+            context.report({
+              node: argument,
+              message:
+                "Avoid nested Layer.provide calls. Extract the inner layer or use Layer.provideMerge.",
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-react-component-inner-functions.ts
+++ b/tools/oxlint/automation/rules/no-react-component-inner-functions.ts
@@ -1,0 +1,304 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+type VisitorObject = ReturnType<NonNullable<Rule["create"]>>;
+type FunctionDeclarationNode = Parameters<
+  NonNullable<VisitorObject["FunctionDeclaration"]>
+>[0];
+type FunctionExpressionNode = Parameters<
+  NonNullable<VisitorObject["FunctionExpression"]>
+>[0];
+type ArrowFunctionExpressionNode = Parameters<
+  NonNullable<VisitorObject["ArrowFunctionExpression"]>
+>[0];
+type FunctionNode =
+  | FunctionDeclarationNode
+  | FunctionExpressionNode
+  | ArrowFunctionExpressionNode;
+
+type Node = {
+  readonly [key: string]: unknown;
+  readonly type: string;
+};
+
+const functionTypes = new Set([
+  "ArrowFunctionExpression",
+  "FunctionDeclaration",
+  "FunctionExpression",
+]);
+
+const expressionWrapperTypes = new Set([
+  "ChainExpression",
+  "ParenthesizedExpression",
+  "TSAsExpression",
+  "TSNonNullExpression",
+  "TSSatisfiesExpression",
+  "TSTypeAssertion",
+]);
+
+const _isNode = (value: unknown): value is Node =>
+  typeof value === "object" &&
+  value !== null &&
+  Object.hasOwn(value, "type") &&
+  typeof Reflect.get(value, "type") === "string";
+
+const _nodeField = ({ field, node }: { field: string; node: Node }) =>
+  node[field];
+
+const _nodeArray = ({ field, node }: { field: string; node: Node }) => {
+  const value = _nodeField({ field, node });
+
+  return Array.isArray(value) ? value.filter(_isNode) : [];
+};
+
+const _nodeName = ({ node }: { node: unknown }) => {
+  if (!_isNode(node)) {
+    return undefined;
+  }
+
+  const name = _nodeField({ field: "name", node });
+
+  return typeof name === "string" ? name : undefined;
+};
+
+const _nodeParent = ({ node }: { node: Node }) => {
+  const parent = _nodeField({ field: "parent", node });
+
+  return _isNode(parent) ? parent : undefined;
+};
+
+const _nodeExpression = ({ node }: { node: Node }) => {
+  const expression = _nodeField({ field: "expression", node });
+
+  return _isNode(expression) ? expression : undefined;
+};
+
+const _isTsxFile = ({ filename }: { filename: string }) =>
+  filename.endsWith(".tsx");
+
+const _isFunction = ({ node }: { node: Node | undefined }) =>
+  node !== undefined && functionTypes.has(node.type);
+
+const _isComponentName = ({ name }: { name: string | undefined }) =>
+  name !== undefined && /^[A-Z]/.test(name);
+
+const _componentName = ({ node }: { node: Node }): string | undefined => {
+  if (node.type === "FunctionDeclaration") {
+    const name = _nodeName({ node: _nodeField({ field: "id", node }) });
+
+    return _isComponentName({ name }) ? name : undefined;
+  }
+
+  const parent = _nodeParent({ node });
+
+  if (parent?.type === "VariableDeclarator") {
+    const name = _nodeName({ node: _nodeField({ field: "id", node: parent }) });
+
+    return _isComponentName({ name }) ? name : undefined;
+  }
+
+  if (parent?.type === "CallExpression") {
+    const variableDeclarator = _nodeParent({ node: parent });
+
+    if (variableDeclarator?.type === "VariableDeclarator") {
+      const name = _nodeName({
+        node: _nodeField({ field: "id", node: variableDeclarator }),
+      });
+
+      return _isComponentName({ name }) ? name : undefined;
+    }
+  }
+
+  return undefined;
+};
+
+const _owningComponent = ({ node }: { node: Node }) => {
+  let current = _nodeParent({ node });
+
+  while (current !== undefined) {
+    if (_isFunction({ node: current })) {
+      const name = _componentName({ node: current });
+
+      return name === undefined ? undefined : { name, node: current };
+    }
+
+    current = _nodeParent({ node: current });
+  }
+
+  return undefined;
+};
+
+const _outerExpression = ({ node }: { node: Node }) => {
+  let current = node;
+  let parent = _nodeParent({ node: current });
+
+  while (
+    parent !== undefined &&
+    expressionWrapperTypes.has(parent.type) &&
+    _nodeExpression({ node: parent }) === current
+  ) {
+    current = parent;
+    parent = _nodeParent({ node: current });
+  }
+
+  return current;
+};
+
+const _isAssignedValue = ({ node }: { node: Node }) => {
+  const parent = _nodeParent({ node });
+
+  return (
+    (parent?.type === "VariableDeclarator" &&
+      _nodeField({ field: "init", node: parent }) === node) ||
+    (parent?.type === "AssignmentExpression" &&
+      _nodeField({ field: "right", node: parent }) === node)
+  );
+};
+
+const _memberPropertyName = ({ node }: { node: Node }) => {
+  const property = _nodeField({ field: "property", node });
+
+  return _isNode(property) && property.type === "Identifier"
+    ? _nodeName({ node: property })
+    : undefined;
+};
+
+const _isUseCallbackCall = ({ node }: { node: Node }) => {
+  const callee = _nodeField({ field: "callee", node });
+
+  if (!_isNode(callee)) {
+    return false;
+  }
+
+  return (
+    (callee.type === "Identifier" &&
+      _nodeName({ node: callee }) === "useCallback") ||
+    (callee.type === "MemberExpression" &&
+      _memberPropertyName({ node: callee }) === "useCallback")
+  );
+};
+
+const _isUseCallbackValue = ({ node }: { node: Node }) => {
+  const expression = _outerExpression({ node });
+  const callExpression = _nodeParent({ node: expression });
+  const [firstArgument] =
+    callExpression === undefined
+      ? []
+      : _nodeArray({ field: "arguments", node: callExpression });
+
+  if (
+    callExpression?.type !== "CallExpression" ||
+    firstArgument !== expression ||
+    !_isUseCallbackCall({ node: callExpression })
+  ) {
+    return false;
+  }
+
+  return _isAssignedValue({
+    node: _outerExpression({ node: callExpression }),
+  });
+};
+
+const _isComponentOwnedFunction = ({ node }: { node: Node }) => {
+  if (node.type === "FunctionDeclaration") {
+    return true;
+  }
+
+  const expression = _outerExpression({ node });
+
+  return (
+    _isAssignedValue({ node: expression }) || _isUseCallbackValue({ node })
+  );
+};
+
+const _functionName = ({ node }: { node: Node }) => {
+  if (node.type === "FunctionDeclaration") {
+    return _nodeName({ node: _nodeField({ field: "id", node }) });
+  }
+
+  const expression = _outerExpression({ node });
+  const parent = _nodeParent({ node: expression });
+
+  if (parent?.type === "VariableDeclarator") {
+    return _nodeName({ node: _nodeField({ field: "id", node: parent }) });
+  }
+
+  if (parent?.type === "AssignmentExpression") {
+    return _nodeName({ node: _nodeField({ field: "left", node: parent }) });
+  }
+
+  if (
+    parent?.type === "CallExpression" &&
+    _isUseCallbackCall({ node: parent })
+  ) {
+    const callbackOwner = _nodeParent({
+      node: _outerExpression({ node: parent }),
+    });
+
+    return (
+      _nodeName({
+        node:
+          callbackOwner === undefined
+            ? undefined
+            : _nodeField({ field: "id", node: callbackOwner }),
+      }) ??
+      _nodeName({
+        node:
+          callbackOwner === undefined
+            ? undefined
+            : _nodeField({ field: "left", node: callbackOwner }),
+      })
+    );
+  }
+
+  return undefined;
+};
+
+const _message = ({ name }: { name: string | undefined }) =>
+  name === undefined
+    ? "Move this component-local function out of the component. If it contains business logic, model it in a state machine or actor instead. Avoid inlining the function into the component body unless no better boundary is possible."
+    : `Move "${name}" out of the component. If it contains business logic, model it in a state machine or actor instead. Avoid inlining the function into the component body unless no better boundary is possible.`;
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Move named component-local functions to a state machine, actor, or external helper.",
+    },
+  },
+  create(context) {
+    const filename = context.filename ?? "";
+
+    if (!_isTsxFile({ filename })) {
+      return {};
+    }
+
+    const check_ = (node: FunctionNode) => {
+      if (!_isNode(node)) {
+        return;
+      }
+
+      if (
+        _nodeField({ field: "body", node }) === undefined ||
+        _owningComponent({ node }) === undefined ||
+        !_isComponentOwnedFunction({ node })
+      ) {
+        return;
+      }
+
+      context.report({
+        node,
+        message: _message({ name: _functionName({ node }) }),
+      });
+    };
+
+    return {
+      ArrowFunctionExpression: check_,
+      FunctionDeclaration: check_,
+      FunctionExpression: check_,
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-shadowed-standard-array-static.ts
+++ b/tools/oxlint/automation/rules/no-shadowed-standard-array-static.ts
@@ -1,0 +1,55 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+const standardArrayMethods = new Set(["from", "isArray", "of"]);
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Require globalThis.Array when Array is imported from effect.",
+    },
+  },
+  create(context) {
+    let arrayImportedFromEffect = false;
+
+    return {
+      ImportDeclaration(node) {
+        if (
+          node.source.value === "effect" &&
+          node.specifiers.some(
+            (specifier) =>
+              specifier.type === "ImportSpecifier" &&
+              specifier.imported.type === "Identifier" &&
+              specifier.imported.name === "Array" &&
+              specifier.local.name === "Array"
+          )
+        ) {
+          arrayImportedFromEffect = true;
+        }
+      },
+      MemberExpression(node) {
+        if (!arrayImportedFromEffect) {
+          return;
+        }
+
+        if (
+          node.object.type === "Identifier" &&
+          node.object.name === "Array" &&
+          node.property.type === "Identifier" &&
+          standardArrayMethods.has(node.property.name)
+        ) {
+          context.report({
+            node,
+            message:
+              "Array is imported from effect in this file. Use globalThis.Array for standard Array static APIs.",
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-silent-error-swallow.ts
+++ b/tools/oxlint/automation/rules/no-silent-error-swallow.ts
@@ -1,0 +1,134 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+type Node = {
+  [key: string]: unknown;
+  type: string;
+};
+
+const catchMethods = new Set([
+  "catch",
+  "catchTag",
+  "catchTags",
+  "catchReason",
+  "catchReasons",
+]);
+
+const message =
+  "Do not silently swallow Effect errors with Effect.void or Effect.unit. Recover meaningfully, transform the error, or let it propagate.";
+
+const isNode = (value: unknown): value is Node =>
+  typeof value === "object" &&
+  value !== null &&
+  "type" in value &&
+  typeof value.type === "string";
+
+const nodeArray = ({ value }: { value: unknown }) =>
+  Array.isArray(value) ? value.filter(isNode) : [];
+
+const nodeName = ({ value }: { value: unknown }) =>
+  isNode(value) && typeof value.name === "string" ? value.name : undefined;
+
+const voidOrUnitMethods = new Set(["void", "unit"]);
+
+const isEffectMember = ({
+  names,
+  node,
+}: {
+  names: Set<string>;
+  node: unknown;
+}) =>
+  isNode(node) &&
+  node.type === "MemberExpression" &&
+  isNode(node.object) &&
+  isNode(node.property) &&
+  node.object.type === "Identifier" &&
+  nodeName({ value: node.object }) === "Effect" &&
+  node.property.type === "Identifier" &&
+  names.has(nodeName({ value: node.property }) ?? "");
+
+const isEffectVoidOrUnit = ({ node }: { node: unknown }) =>
+  isEffectMember({ names: voidOrUnitMethods, node });
+
+const returnsOnlyVoid = ({ node }: { node: unknown }) => {
+  if (
+    !isNode(node) ||
+    (node.type !== "ArrowFunctionExpression" &&
+      node.type !== "FunctionExpression")
+  ) {
+    return false;
+  }
+
+  if (isEffectVoidOrUnit({ node: node.body })) {
+    return true;
+  }
+
+  if (!isNode(node.body) || node.body.type !== "BlockStatement") {
+    return false;
+  }
+
+  const statements = nodeArray({ value: node.body.body });
+
+  if (statements.length !== 1) {
+    return false;
+  }
+
+  const statement = statements[0];
+
+  return (
+    statement?.type === "ReturnStatement" &&
+    isEffectVoidOrUnit({ node: statement.argument })
+  );
+};
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Do not silently swallow Effect errors; recover, transform, or propagate them.",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          !isEffectMember({
+            names: catchMethods,
+            node: node.callee,
+          })
+        ) {
+          return;
+        }
+
+        for (const argument of nodeArray({ value: node.arguments })) {
+          if (returnsOnlyVoid({ node: argument })) {
+            context.report({
+              node,
+              message,
+            });
+          }
+
+          if (!isNode(argument) || argument.type !== "ObjectExpression") {
+            continue;
+          }
+
+          for (const property of nodeArray({ value: argument.properties })) {
+            if (
+              property.type === "Property" &&
+              returnsOnlyVoid({ node: property.value })
+            ) {
+              context.report({
+                node,
+                message,
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-sql-type-parameter.ts
+++ b/tools/oxlint/automation/rules/no-sql-type-parameter.ts
@@ -1,0 +1,39 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Avoid sql<Type> templates; use typed query APIs or validated schemas.",
+    },
+  },
+  create(context) {
+    return {
+      TaggedTemplateExpression(node) {
+        const isSqlTag =
+          (node.tag.type === "Identifier" && node.tag.name === "sql") ||
+          (node.tag.type === "MemberExpression" &&
+            node.tag.property.type === "Identifier" &&
+            node.tag.property.name === "sql");
+        const hasTypeParameters =
+          (node.typeArguments !== undefined && node.typeArguments !== null) ||
+          ("typeParameters" in node &&
+            node.typeParameters !== undefined &&
+            node.typeParameters !== null);
+
+        if (isSqlTag && hasTypeParameters) {
+          context.report({
+            node,
+            message:
+              "Do not use sql<Type> templates. Use typed Drizzle/D1 query APIs or validated schemas instead.",
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-static-effect-service-forwarders.ts
+++ b/tools/oxlint/automation/rules/no-static-effect-service-forwarders.ts
@@ -1,0 +1,358 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+type VisitorObject = ReturnType<NonNullable<Rule["create"]>>;
+type CallExpressionNode = Parameters<
+  NonNullable<VisitorObject["CallExpression"]>
+>[0];
+type ImportDeclarationNode = Parameters<
+  NonNullable<VisitorObject["ImportDeclaration"]>
+>[0];
+type IdentifierNode = Parameters<NonNullable<VisitorObject["Identifier"]>>[0];
+type CallbackExpression = {
+  expression: unknown;
+  parameterName: string | undefined;
+};
+
+const message =
+  "Do not expose an Effect service method through a static forwarder. Yield the service at the usage site and call the method directly.";
+
+const _nodeName = ({ node }: { node: unknown }) =>
+  typeof node === "object" &&
+  node !== null &&
+  "name" in node &&
+  typeof node.name === "string"
+    ? node.name
+    : undefined;
+
+const _isCallExpressionNode = (node: unknown): node is CallExpressionNode =>
+  typeof node === "object" &&
+  node !== null &&
+  "type" in node &&
+  node.type === "CallExpression";
+
+const _isIdentifierNode = (node: unknown): node is IdentifierNode =>
+  typeof node === "object" &&
+  node !== null &&
+  "type" in node &&
+  node.type === "Identifier";
+
+const _importedName = ({
+  specifier,
+}: {
+  specifier: ImportDeclarationNode["specifiers"][number];
+}) =>
+  specifier.type === "ImportSpecifier"
+    ? _nodeName({ node: specifier.imported })
+    : undefined;
+
+const _isStaticClassField = ({ node }: { node: CallExpressionNode }) => {
+  let current: unknown = node.parent;
+
+  while (typeof current === "object" && current !== null && "type" in current) {
+    if (current.type === "PropertyDefinition") {
+      return "static" in current && current.static === true;
+    }
+
+    if (current.type === "Program") {
+      return false;
+    }
+
+    current = "parent" in current ? current.parent : undefined;
+  }
+
+  return false;
+};
+
+const _callbackExpression = ({
+  node,
+}: {
+  node: unknown;
+}): CallbackExpression | undefined => {
+  if (typeof node !== "object" || node === null || !("type" in node)) {
+    return undefined;
+  }
+
+  if (
+    node.type !== "ArrowFunctionExpression" &&
+    node.type !== "FunctionExpression"
+  ) {
+    return undefined;
+  }
+
+  if (!("params" in node) || !Array.isArray(node.params)) {
+    return undefined;
+  }
+
+  const [parameter] = node.params;
+  if (
+    node.params.length !== 1 ||
+    typeof parameter !== "object" ||
+    parameter === null ||
+    !("type" in parameter) ||
+    parameter.type !== "Identifier"
+  ) {
+    return undefined;
+  }
+
+  if (
+    !("body" in node) ||
+    typeof node.body !== "object" ||
+    node.body === null
+  ) {
+    return undefined;
+  }
+
+  if (!("type" in node.body) || node.body.type !== "BlockStatement") {
+    return {
+      expression: node.body,
+      parameterName: _nodeName({ node: parameter }),
+    };
+  }
+
+  if (!("body" in node.body) || !Array.isArray(node.body.body)) {
+    return undefined;
+  }
+
+  const [statement] = node.body.body;
+  if (
+    node.body.body.length !== 1 ||
+    typeof statement !== "object" ||
+    statement === null ||
+    !("type" in statement) ||
+    statement.type !== "ReturnStatement" ||
+    !("argument" in statement)
+  ) {
+    return undefined;
+  }
+
+  return {
+    expression: statement.argument,
+    parameterName: _nodeName({ node: parameter }),
+  };
+};
+
+const _isDirectParameterMember = ({
+  expression,
+  parameterName,
+}: {
+  expression: unknown;
+  parameterName: string | undefined;
+}) => {
+  if (
+    parameterName === undefined ||
+    typeof expression !== "object" ||
+    expression === null ||
+    !("type" in expression)
+  ) {
+    return false;
+  }
+
+  const member =
+    expression.type === "CallExpression" &&
+    "callee" in expression &&
+    typeof expression.callee === "object" &&
+    expression.callee !== null
+      ? expression.callee
+      : expression;
+
+  return (
+    "type" in member &&
+    member.type === "MemberExpression" &&
+    "object" in member &&
+    typeof member.object === "object" &&
+    member.object !== null &&
+    "type" in member.object &&
+    member.object.type === "Identifier" &&
+    _nodeName({ node: member.object }) === parameterName
+  );
+};
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Disallow static Effect service method forwarders; acquire the service where its method is used.",
+    },
+  },
+  create(context) {
+    const effectNamespaceNames = new Set<string>();
+    const flatMapNames = new Set<string>();
+    const serviceNames = new Set<string>();
+    const pipeNames = new Set<string>();
+
+    const isImportedIdentifier = ({
+      names,
+      node,
+    }: {
+      names: ReadonlySet<string>;
+      node: IdentifierNode;
+    }) => {
+      if (!names.has(node.name)) {
+        return false;
+      }
+
+      let scope: ReturnType<typeof context.sourceCode.getScope> | null =
+        context.sourceCode.getScope(node);
+
+      while (scope !== null) {
+        const variable = scope.set.get(node.name);
+        if (variable !== undefined) {
+          return variable.defs.some(
+            (definition) => definition.type === "ImportBinding"
+          );
+        }
+
+        scope = scope.upper;
+      }
+
+      return false;
+    };
+
+    const effectCall = ({
+      name,
+      names,
+      node,
+    }: {
+      name: "flatMap" | "service";
+      names: ReadonlySet<string>;
+      node: unknown;
+    }): CallExpressionNode | undefined => {
+      if (!_isCallExpressionNode(node)) {
+        return undefined;
+      }
+
+      if (_isIdentifierNode(node.callee)) {
+        return isImportedIdentifier({
+          names,
+          node: node.callee,
+        })
+          ? node
+          : undefined;
+      }
+
+      return node.callee.type === "MemberExpression" &&
+        _isIdentifierNode(node.callee.object) &&
+        isImportedIdentifier({
+          names: effectNamespaceNames,
+          node: node.callee.object,
+        }) &&
+        _nodeName({ node: node.callee.property }) === name
+        ? node
+        : undefined;
+    };
+
+    const isServiceThisCall = ({ node }: { node: unknown }) => {
+      const call = effectCall({ name: "service", names: serviceNames, node });
+      return (
+        call !== undefined &&
+        call.arguments.length === 1 &&
+        call.arguments[0]?.type === "ThisExpression"
+      );
+    };
+
+    const isForwardingFlatMap = ({ node }: { node: unknown }) => {
+      const call = effectCall({ name: "flatMap", names: flatMapNames, node });
+      if (call === undefined) {
+        return false;
+      }
+
+      const callback = _callbackExpression({ node: call.arguments.at(-1) });
+      return callback !== undefined && _isDirectParameterMember(callback);
+    };
+
+    const isPipeCall = ({ node }: { node: CallExpressionNode }) => {
+      if (node.callee.type === "Identifier") {
+        return isImportedIdentifier({
+          names: pipeNames,
+          node: node.callee,
+        });
+      }
+
+      return (
+        node.callee.type === "MemberExpression" &&
+        _nodeName({ node: node.callee.property }) === "pipe"
+      );
+    };
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === "effect") {
+          for (const specifier of node.specifiers) {
+            if (
+              specifier.type === "ImportSpecifier" &&
+              _importedName({ specifier }) === "Effect"
+            ) {
+              effectNamespaceNames.add(specifier.local.name);
+            }
+
+            if (
+              specifier.type === "ImportSpecifier" &&
+              _importedName({ specifier }) === "pipe"
+            ) {
+              pipeNames.add(specifier.local.name);
+            }
+          }
+          return;
+        }
+
+        if (node.source.value !== "effect/Effect") {
+          return;
+        }
+
+        for (const specifier of node.specifiers) {
+          if (specifier.type === "ImportNamespaceSpecifier") {
+            effectNamespaceNames.add(specifier.local.name);
+            continue;
+          }
+
+          const importedName = _importedName({ specifier });
+          if (importedName === "flatMap") {
+            flatMapNames.add(specifier.local.name);
+          } else if (importedName === "service") {
+            serviceNames.add(specifier.local.name);
+          }
+        }
+      },
+      CallExpression(node) {
+        if (!_isStaticClassField({ node })) {
+          return;
+        }
+
+        if (
+          effectCall({ name: "flatMap", names: flatMapNames, node }) !==
+            undefined &&
+          node.arguments.length >= 2 &&
+          isServiceThisCall({ node: node.arguments[0] }) &&
+          isForwardingFlatMap({ node })
+        ) {
+          context.report({ message, node });
+          return;
+        }
+
+        if (!isPipeCall({ node })) {
+          return;
+        }
+
+        const pipedEffect =
+          node.callee.type === "MemberExpression"
+            ? node.callee.object
+            : node.arguments[0];
+        const operators =
+          node.callee.type === "MemberExpression"
+            ? node.arguments
+            : node.arguments.slice(1);
+
+        if (
+          isServiceThisCall({ node: pipedEffect }) &&
+          operators.some((operator) => isForwardingFlatMap({ node: operator }))
+        ) {
+          context.report({ message, node });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-switch.ts
+++ b/tools/oxlint/automation/rules/no-switch.ts
@@ -1,0 +1,26 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+const message = "Switch statements are banned. Use Match from effect.";
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description: "Disallow switch statements. Use Match from effect instead.",
+    },
+  },
+  create(context) {
+    return {
+      SwitchStatement(node) {
+        context.report({
+          node,
+          message,
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-try-catch.ts
+++ b/tools/oxlint/automation/rules/no-try-catch.ts
@@ -1,0 +1,28 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+const message =
+  "Do not use try/catch. Use Effect.try, Effect.tryPromise, or explicit error channels instead.";
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Avoid try/catch; use Effect.try, Effect.tryPromise, or explicit error channels.",
+    },
+  },
+  create(context) {
+    return {
+      TryStatement(node) {
+        context.report({
+          node,
+          message,
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/no-typeof-object.ts
+++ b/tools/oxlint/automation/rules/no-typeof-object.ts
@@ -1,0 +1,45 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+const isObjectLiteral = (node: { type: string; value?: unknown }) =>
+  node.type === "Literal" && node.value === "object";
+
+const isTypeofExpression = (node: { type: string; operator?: string }) =>
+  node.type === "UnaryExpression" && node.operator === "typeof";
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Avoid typeof object checks; prefer Effect Schema or explicit null and object validation.",
+    },
+  },
+  create(context) {
+    return {
+      BinaryExpression(node) {
+        if (
+          !(
+            (node.operator === "===" ||
+              node.operator === "!==" ||
+              node.operator === "==" ||
+              node.operator === "!=") &&
+            ((isTypeofExpression(node.left) && isObjectLiteral(node.right)) ||
+              (isObjectLiteral(node.left) && isTypeofExpression(node.right)))
+          )
+        ) {
+          return;
+        }
+
+        context.report({
+          node,
+          message:
+            'Do not compare typeof values with "object". First consider whether Effect Schema is a better solution and whether this runtime check is necessary. If it is necessary, use an explicit null and object validation helper instead.',
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/pipe-max-arguments.ts
+++ b/tools/oxlint/automation/rules/pipe-max-arguments.ts
@@ -1,0 +1,35 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+const maxPipeArguments = 20;
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Limit pipe calls to 20 arguments; split longer pipelines into named steps.",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.property.type === "Identifier" &&
+          node.callee.property.name === "pipe" &&
+          node.arguments.length > maxPipeArguments
+        ) {
+          context.report({
+            node,
+            message:
+              "This pipe has too many arguments. Split it into smaller named steps.",
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/prefer-effect-match.ts
+++ b/tools/oxlint/automation/rules/prefer-effect-match.ts
@@ -1,0 +1,111 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+type Node = {
+  [key: string]: unknown;
+  range: [number, number];
+  type: string;
+};
+
+const equalityOperators = new Set(["==", "===", "!=", "!=="]);
+
+const isNode = (value: unknown): value is Node =>
+  typeof value === "object" &&
+  value !== null &&
+  "type" in value &&
+  typeof value.type === "string" &&
+  "range" in value &&
+  Array.isArray(value.range);
+
+const isLiteral = (node: unknown) =>
+  isNode(node) &&
+  (node.type === "Literal" ||
+    (node.type === "TemplateLiteral" &&
+      Array.isArray(node.expressions) &&
+      node.expressions.length === 0));
+
+const getComparedValue = ({
+  node,
+  getText,
+}: {
+  node: unknown;
+  getText: (node: Node) => string;
+}) => {
+  if (
+    !isNode(node) ||
+    node.type !== "BinaryExpression" ||
+    typeof node.operator !== "string" ||
+    !equalityOperators.has(node.operator)
+  ) {
+    return undefined;
+  }
+
+  if (isLiteral(node.left) && isNode(node.right)) {
+    return getText(node.right);
+  }
+
+  if (isNode(node.left) && isLiteral(node.right)) {
+    return getText(node.left);
+  }
+
+  return undefined;
+};
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Use Match from effect for chained literal ternaries over the same value.",
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+    const getText = (node: Node) => sourceCode.getText(node);
+
+    return {
+      ConditionalExpression(node) {
+        if (node.parent?.type === "ConditionalExpression") {
+          return;
+        }
+
+        const comparedValue = getComparedValue({
+          node: node.test,
+          getText,
+        });
+
+        if (comparedValue === undefined) {
+          return;
+        }
+
+        let alternate = node.alternate;
+        let literalChecks = 1;
+
+        while (alternate.type === "ConditionalExpression") {
+          const alternateComparedValue = getComparedValue({
+            node: alternate.test,
+            getText,
+          });
+
+          if (alternateComparedValue !== comparedValue) {
+            return;
+          }
+
+          literalChecks += 1;
+          alternate = alternate.alternate;
+        }
+
+        if (literalChecks > 1) {
+          context.report({
+            node,
+            message:
+              "Use Match from effect instead of a chained literal ternary.",
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/oxlint/automation/rules/prefer-option-from-nullable.ts
+++ b/tools/oxlint/automation/rules/prefer-option-from-nullable.ts
@@ -1,0 +1,86 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+type Rule = Parameters<RuleTester["run"]>[1];
+
+type Node = {
+  [key: string]: unknown;
+  type: string;
+};
+
+const isNode = (value: unknown): value is Node =>
+  typeof value === "object" &&
+  value !== null &&
+  "type" in value &&
+  typeof value.type === "string";
+
+const isNullLiteral = (node: unknown) =>
+  isNode(node) && node.type === "Literal" && node.value === null;
+
+const isOptionMemberCall = ({
+  name,
+  node,
+}: {
+  name: string;
+  node: unknown;
+}) => {
+  if (!isNode(node) || node.type !== "CallExpression") {
+    return false;
+  }
+
+  const callee = node.callee;
+  const member =
+    isNode(callee) && callee.type === "MemberExpression"
+      ? callee
+      : isNode(callee) && callee.type === "TSInstantiationExpression"
+        ? isNode(callee.expression)
+          ? callee.expression
+          : undefined
+        : undefined;
+
+  return (
+    isNode(member) &&
+    member.type === "MemberExpression" &&
+    isNode(member.object) &&
+    isNode(member.property) &&
+    member.object.type === "Identifier" &&
+    member.object.name === "Option" &&
+    member.property.type === "Identifier" &&
+    member.property.name === name
+  );
+};
+
+const rule: Rule = {
+  meta: {
+    type: "problem" as const,
+    docs: {
+      description:
+        "Use Option.fromNullable instead of ternaries that choose between Option.some and Option.none.",
+    },
+  },
+  create(context) {
+    return {
+      ConditionalExpression(node) {
+        if (
+          node.test.type !== "BinaryExpression" ||
+          (node.test.operator !== "!==" && node.test.operator !== "!=") ||
+          (!isNullLiteral(node.test.left) && !isNullLiteral(node.test.right))
+        ) {
+          return;
+        }
+
+        if (
+          isOptionMemberCall({ name: "some", node: node.consequent }) &&
+          isOptionMemberCall({ name: "none", node: node.alternate })
+        ) {
+          context.report({
+            node,
+            message:
+              "Use Option.fromNullable instead of a nullable ternary with Option.some and Option.none.",
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;


### PR DESCRIPTION
## Problem

The existing lint configuration did not enforce the anti-slop or automation rules, so chained casts, unverified assertions, and ambient randomness could pass CI. Installing their agent skills is unnecessary: the checks should run directly through the repository's existing Oxlint command.

## Solution

- Vendor all 15 generic anti-slop rules and its Effect service-constructor rule from `dmmulroy/anti-slop@e8c4880471b23ab7f216fba7b27d173a6ef07d4c`.
- Vendor 22 compatible Oxlint rules from `typeonce-dev/ai-automation@0bca096fe6fe9878cd15303a623dd2cd85915ddd`, enabled as errors. No skills or additional automation engines are installed.
- Pin `oxlint` and `@oxlint/plugins` together at `1.78.0`; no matching plugin package exists for the previous Oxlint `1.47.0`. Register plugin entry points with Knip and exclude vendored sources from linting/formatting while retaining typechecking.
- Fix findings in source, examples, and tests: remove unnecessary casts, justify remaining assertions, use Effect predicates and Random, compose independent layer dependencies together, and acquire the benchmark store through its Layer.
- Preserve upstream source provenance and document maintenance steps. Anti-slop has one small compatibility adaptation for `noUncheckedIndexedAccess`.

[The automation README](tools/oxlint/automation/README.md) documents exclusions: bans on comments, positional/optional parameters, serviceOption, React state hooks, and other application-specific conventions do not fit this library. Narrow overrides permit Date reads in the two React clock hooks and JSON serialization in the benchmark reporter.

## Examples

An Option is now unwrapped through its API instead of asserting its variant:

```ts
// Before
return (task as Option.Some<Progress.TaskSnapshot>).value;

// After
return Option.getOrThrow(task);
```

Example randomness now runs through Effect:

```ts
// Before
const score = Math.round(Math.random() * 40 + 60);

// After, inside Effect.gen
const score = Math.round(yield* Random.nextBetween(60, 100));
```

The renderer test helper now accepts only effects whose remaining requirement it can provide (`ProgressStdio`), removing the cast that previously erased arbitrary requirements.

**Type migration:** the exported `ProgressShape` and `ProgressStdioShape` interfaces are now `ProgressService` and `ProgressStdioService`. Consumers importing those names must update their type imports. Internal store and renderer interfaces follow the same naming convention. Runtime task behavior and dual/pipeable APIs are retained.

## Validation

- `bun run check`: typechecking, lint, formatting, and Knip pass.
- `bun test`: all 124 existing tests pass.
- `bun test tests/utils.test.ts`: all 8 tests pass, including added coverage for collection size inference and non-consumption of custom iterables.
- Temporary negative fixtures confirm all three plugin entry points reject violations; a positive fixture passes the combined configuration.
- `git diff --check` passes.
