### PR TITLE
Acquire the Ink renderer as a scoped resource

### DIFF
--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -15,7 +15,6 @@ interface CurrentParentState {
 const makeProgressService = Effect.gen(function* () {
   const inkRenderer = yield* Renderer;
   const store = yield* ProgressStore;
-  const scope = yield* Effect.scope;
   const parentOwner = Symbol();
 
   // Each Progress service has its own task store, but they all share CurrentParent.
@@ -26,9 +25,7 @@ const makeProgressService = Effect.gen(function* () {
       : Option.none<TaskId>(),
   );
 
-  yield* Effect.forkIn(inkRenderer.run, scope, { startImmediately: true });
-  // Let the renderer fiber start so queued logs are reliably flushed on scope teardown.
-  yield* Effect.sleep("0 millis");
+  yield* inkRenderer.start;
 
   const addTask = <M>(options: AddTaskOptions<M>) =>
     Effect.gen(function* () {

--- a/src/services/renderer/renderer.tsx
+++ b/src/services/renderer/renderer.tsx
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer } from "effect";
+import { Context, Effect, Layer, type Scope } from "effect";
 import { render } from "ink";
 import { NowProvider } from "./context/now-context";
 import { SpinnerProvider } from "./context/spinner-context";
@@ -8,7 +8,7 @@ import { useProgressRenderView } from "./hooks/use-progress-render-view";
 import { ProgressStdio } from "../stdio";
 
 interface RendererService {
-  readonly run: Effect.Effect<void>;
+  readonly start: Effect.Effect<void, never, Scope.Scope>;
 }
 
 const MAX_FPS = 24;
@@ -31,30 +31,24 @@ const makeRendererService = Effect.gen(function* () {
   const proot = <ProgressRoot store={store} />;
 
   return {
-    run: Effect.sync(() =>
-      render(proot, {
-        stdout: stdio.stdout,
-        stderr: stdio.stderr,
-        patchConsole: true,
-        exitOnCtrlC: false,
-        debug: false,
-        maxFps: MAX_FPS,
-      }),
-    ).pipe(
-      Effect.flatMap((instance) =>
-        Effect.never.pipe(
-          Effect.ensuring(
-            Effect.gen(function* () {
-              store.flush();
-              instance.rerender(proot);
-              yield* Effect.sync(() => {
-                instance.unmount();
-              });
-            }),
-          ),
-        ),
+    start: Effect.acquireRelease(
+      Effect.sync(() =>
+        render(proot, {
+          stdout: stdio.stdout,
+          stderr: stdio.stderr,
+          patchConsole: true,
+          exitOnCtrlC: false,
+          debug: false,
+          maxFps: MAX_FPS,
+        }),
       ),
-    ),
+      (instance) =>
+        Effect.sync(() => {
+          store.flush();
+          instance.rerender(proot);
+          instance.unmount();
+        }),
+    ).pipe(Effect.as(undefined)),
   } satisfies RendererService;
 });
 

--- a/tests/renderer-lifecycle.test.ts
+++ b/tests/renderer-lifecycle.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { Effect, Exit } from "effect";
+import { Progress } from "../src/services/progress";
+import { Renderer } from "../src/services/renderer/renderer";
+
+test.each([false, true])(
+  "renderer starts before work and releases on scope exit (failure: %s)",
+  async (fail) => {
+    const events: string[] = [];
+    const start = Effect.acquireRelease(
+      Effect.sync(() => {
+        events.push("start");
+      }),
+      () =>
+        Effect.sync(() => {
+          events.push("release");
+        }),
+    );
+    const exit = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* Progress;
+        events.push("work");
+        if (fail) {
+          return yield* Effect.fail("failure");
+        }
+      }).pipe(
+        Effect.provide(Progress.layer),
+        Effect.provideService(Renderer, { start }),
+        Effect.scoped,
+        Effect.exit,
+      ),
+    );
+    expect(events).toEqual(["start", "work", "release"]);
+    expect(Exit.isFailure(exit)).toBe(fail);
+  },
+);

--- a/tests/task-finalization.test.ts
+++ b/tests/task-finalization.test.ts
@@ -6,7 +6,7 @@ import { Renderer } from "../src/services/renderer/renderer";
 const withProgress = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   effect.pipe(
     Effect.provide(Progress.Progress.layer),
-    Effect.provideService(Renderer, { run: Effect.never }),
+    Effect.provideService(Renderer, { start: Effect.void }),
     Effect.scoped,
   );
 

--- a/tests/task-scopes.test.ts
+++ b/tests/task-scopes.test.ts
@@ -92,7 +92,7 @@ describe("Progress task scopes", () => {
     });
 
     const innerTask = await Effect.runPromise(
-      withStdio(Effect.provideService(outer, Renderer, { run: Effect.never })),
+      withStdio(Effect.provideService(outer, Renderer, { start: Effect.void })),
     );
 
     expect(innerTask.parentId).toBeNull();


### PR DESCRIPTION
Progress initialization now acquires the Ink renderer as a scoped resource. Startup completes before task work starts, and scope release flushes the final snapshot and unmounts Ink.

**Problem and before example**

The service previously forked a long-running renderer effect and yielded to give it time to start:

```ts
yield* Effect.forkIn(inkRenderer.run, scope, { startImmediately: true });
yield* Effect.sleep("0 millis");
```

The renderer rendered once and then used `Effect.never` plus an interruption finalizer to keep the Ink instance alive. Its lifetime therefore required both a background fiber and a startup scheduling workaround.

**Solution and after example**

Initialization now directly acquires the renderer:

```ts
yield* inkRenderer.start;
```

The renderer owns its resource lifetime using this pattern:

```ts
Effect.acquireRelease(
  Effect.sync(() => render(proot, options)),
  (instance) => Effect.sync(() => {
    store.flush();
    instance.rerender(proot);
    instance.unmount();
  }),
);
```

There is no renderer fiber or infinite wait. The internal renderer override changes from `{ run: Effect.never }` to `{ start: Effect.void }` for a no-op renderer. Public progress APIs are unchanged.

**Validation**

- `bun run check` passes: typechecking, lint, formatting, and Knip.
- `bun test`: 127 passing tests. New lifecycle cases assert acquisition before work and release after both success and failure; existing Ink integration, logging-without-tasks, teardown, and interruption tests also pass.
- All four refactors apply together without conflicts and pass the combined check/test suite.

Independent PR targeting `main`.
