### PR TITLE
Unify task overloads around a typed callback runner

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -7,11 +7,11 @@ import type {
   AddTaskOptions,
   ProgressService,
   TaskCountDisplay,
-  TaskApi,
   TaskHandle,
   TaskId,
   TrackOptions,
 } from "./types";
+import { adaptTaskApi } from "./task-api";
 import { inferTotal } from "./utils";
 
 const provideProgress = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
@@ -58,24 +58,18 @@ export type TaskOptions<M = void> = AddTaskOptions<M>;
  * typed `TaskHandle` for task-local updates, typed metadata, and explicit completion or failure,
  * and otherwise auto-finalizes from the callback exit if the task is still `running`.
  */
-export const task: TaskApi<Progress | Task> = dual(
-  2,
-  <A, E, R>(
-    effectOrCallback:
-      | Effect.Effect<A, E, R>
-      | ((handle: TaskHandle<any>) => Effect.Effect<A, E, R>),
-    options: TaskOptions<any>,
-  ) => {
-    // SAFETY: provideProgress supplies Progress and progress.task supplies Task for both overloads.
-    return provideProgress(
+export const task = adaptTaskApi<Progress | Task>(
+  <M, A, E, R>(
+    callback: (handle: TaskHandle<M>) => Effect.Effect<A, E, R>,
+    options: AddTaskOptions<M> & { readonly metadata: M },
+  ) =>
+    // SAFETY: The service supplies Task and provideProgress supplies Progress; nested Excludes are equivalent.
+    provideProgress(
       Effect.gen(function* () {
         const progress = yield* Progress;
-        return yield* Effect.isEffect(effectOrCallback)
-          ? progress.task(effectOrCallback, options)
-          : progress.task(effectOrCallback, options);
+        return yield* progress.task(callback, options);
       }),
-    ) as Effect.Effect<A, E, Exclude<R, Progress | Task>>;
-  },
+    ) as Effect.Effect<A, E, Exclude<R, Progress | Task>>,
 );
 
 type AllArg =

--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -1,5 +1,5 @@
 import { Context, Effect, Exit, Layer, Option } from "effect";
-import { dual } from "effect/Function";
+import { adaptTaskApi } from "../task-api";
 import { ProgressStore } from "./store/store";
 import type { AddTaskOptions, ProgressService, TaskHandle, TaskId } from "../types";
 import { Task } from "../types";
@@ -58,40 +58,24 @@ const makeProgressService = Effect.gen(function* () {
     getSnapshot: store.getTask(taskId).pipe(Effect.map(Option.getOrThrow)),
   });
 
-  const scopedTask = <A, E, R>(effect: Effect.Effect<A, E, R>, options: AddTaskOptions) =>
-    Effect.gen(function* () {
-      const taskId = yield* addTask(options);
-
-      return yield* Effect.provideService(
-        Effect.provideService(effect, Task, taskId),
-        CurrentParent,
-        Option.some({ owner: parentOwner, taskId }),
-      );
-    });
-
-  const task: ProgressService["task"] = dual(
-    2,
-    <A, E, R>(
-      effectOrCallback:
-        | Effect.Effect<A, E, R>
-        | ((handle: TaskHandle<any>) => Effect.Effect<A, E, R>),
-      options: AddTaskOptions<any>,
+  const task = adaptTaskApi<Task>(
+    <M, A, E, R>(
+      callback: (handle: TaskHandle<M>) => Effect.Effect<A, E, R>,
+      options: AddTaskOptions<M>,
     ) =>
-      scopedTask(
-        Effect.gen(function* () {
-          const taskId = yield* Task;
-          return yield* Effect.onExit(
-            Effect.suspend(() =>
-              Effect.isEffect(effectOrCallback)
-                ? effectOrCallback
-                : effectOrCallback(makeTaskHandle(taskId)),
-            ),
-            // Store finalization is terminal, so explicit completion/failure always wins.
-            (exit) => (Exit.isSuccess(exit) ? store.completeTask(taskId) : store.failTask(taskId)),
-          );
-        }),
-        options,
-      ),
+      Effect.gen(function* () {
+        const taskId = yield* addTask(options);
+        const handle = makeTaskHandle<M>(taskId);
+        const work = Effect.onExit(
+          Effect.suspend(() => callback(handle)),
+          // Explicit completion/failure wins because store finalization is terminal.
+          (exit) => (Exit.isSuccess(exit) ? store.completeTask(taskId) : store.failTask(taskId)),
+        );
+        return yield* work.pipe(
+          Effect.provideService(Task, taskId),
+          Effect.provideService(CurrentParent, Option.some({ owner: parentOwner, taskId })),
+        );
+      }),
   );
 
   const service = {

--- a/src/task-api.ts
+++ b/src/task-api.ts
@@ -1,0 +1,18 @@
+import { Effect } from "effect";
+import { dual } from "effect/Function";
+import type { AddTaskOptions, TaskApi, TaskHandle } from "./types";
+
+/** Adapts the public overloads to one callback runner. Omitted metadata is the void overload. */
+export const adaptTaskApi = <Provided>(
+  run: <M, A, E, R>(
+    callback: (handle: TaskHandle<M>) => Effect.Effect<A, E, R>,
+    options: AddTaskOptions<M> & { readonly metadata: M },
+  ) => Effect.Effect<A, E, Exclude<R, Provided>>,
+): TaskApi<Provided> =>
+  dual(
+    2,
+    <M, A, E, R>(
+      input: Effect.Effect<A, E, R> | ((handle: TaskHandle<M>) => Effect.Effect<A, E, R>),
+      options: AddTaskOptions<M> & { readonly metadata: M },
+    ) => run((handle) => (Effect.isEffect(input) ? input : input(handle)), options),
+  );


### PR DESCRIPTION
Both task entry points now adapt their overloads to a generic callback runner. The service creates the task, provides its context, invokes the callback, and finalizes it in one place.

**Problem and before example**

The implementation previously erased metadata types at both overload boundaries:

```ts
effectOrCallback:
  | Effect.Effect<A, E, R>
  | ((handle: TaskHandle<any>) => Effect.Effect<A, E, R>);
options: AddTaskOptions<any>;
```

The service passed an effect through `scopedTask`, created its task ID there, and then read `Task` back from context to recover that ID. Both entry points also handled the effect-versus-callback distinction.

**Solution and after example**

`adaptTaskApi` normalizes plain effects and callbacks while preserving `M`, and supplies the existing data-first/data-last overloads. The service runner works directly with its newly created ID and typed handle:

```ts
const taskId = yield* addTask(options);
const handle = makeTaskHandle<M>(taskId);
const work = Effect.onExit(
  Effect.suspend(() => callback(handle)),
  (exit) => Exit.isSuccess(exit)
    ? store.completeTask(taskId)
    : store.failTask(taskId),
);
```

The public wrapper only provides/reuses the service and delegates. Usage stays the same, including typed metadata:

```ts
Progress.task(
  (handle) => handle.updateMetadata((metadata) => ({ score: metadata.score + 1 })),
  { description: "score", metadata: { score: 0 } },
);
```

Callback construction remains suspended, explicit finalization still wins, and the owner check preserves isolation between nested services. One documented context assertion remains because TypeScript does not equate the nested `Exclude` types.

**Validation**

- `bun run check` passes: typechecking, lint, formatting, and Knip.
- `bun test`: 125 passing tests, including overload inference, pipe forms, callback defects, interruption, explicit finalization, and nested-service isolation.
- All four refactors apply together without conflicts and pass the combined check/test suite.

Independent PR targeting `main`.
