### PR TITLE
Bind prepared column data before rendering cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,10 @@ const program = Progress.task(
 - sizing hints with `flexGrow`, `flexShrink`, `flexBasis`, and `minWidth`
 - `align` with `"left"`, `"center"`, or `"right"`
 
+Use `ColumnDef<M, P>` to author a column with typed metadata and prepared data, and
+`Column<M>` for a list containing columns with different prepared types. The renderer
+binds each prepared value to its definition before rendering cells.
+
 If a task does not provide `columns`, the renderer falls back to `Progress.Columns.defaults()`.
 
 ## Performance benchmarks

--- a/examples/benchmarks.ts
+++ b/examples/benchmarks.ts
@@ -96,7 +96,7 @@ const makeColumnFixture = (rowCount: number, distinctPrepare: boolean) => {
     if (distinctPrepare) {
       const column: ColumnDef<unknown, number> = {
         prepare: (cells) => index + cells.reduce((sum, cell) => sum + cell.task.units.processed, 0),
-        render: () => null,
+        render: (_cell, { prepared }) => String(prepared),
       };
       store.columns.set(id, [column]);
     }
@@ -108,15 +108,15 @@ const makeColumnFixture = (rowCount: number, distinctPrepare: boolean) => {
   };
 };
 
-// Compare layout/prepared output without comparing newly allocated render function identities.
+// Compare layout and rendered output without exposing prepared data or comparing callback identities.
 const columnOutput = (positions: ReturnType<typeof resolveColumns>) =>
-  positions.map(({ index, flexGrow, flexShrink, flexBasis, minWidth, entries }) => ({
+  positions.map(({ index, flexGrow, flexShrink, flexBasis, minWidth, entries, rows }) => ({
     index,
     flexGrow,
     flexShrink,
     flexBasis,
     minWidth,
-    prepared: entries.map((entry) => entry?.prepared),
+    output: entries.map((entry, index) => entry?.render(rows[index]!, { now: 0, spinnerTick: 0 })),
   }));
 
 const benchmarkColumns = (rowCount: number, distinctPrepare: boolean): Measurement => {
@@ -126,7 +126,9 @@ const benchmarkColumns = (rowCount: number, distinctPrepare: boolean): Measureme
   for (const position of result) {
     assert.equal(position.entries.length, rowCount);
     if (distinctPrepare) {
-      position.entries.forEach((entry, index) => assert.equal(entry?.prepared, index + 25));
+      position.entries.forEach((entry, index) =>
+        assert.equal(entry?.render(rows[index]!, { now: 0, spinnerTick: 0 }), String(index + 25)),
+      );
     }
   }
   const expected = columnOutput(result);

--- a/examples/mixedNestedColumns.ts
+++ b/examples/mixedNestedColumns.ts
@@ -63,7 +63,7 @@ const cachePhaseColumn = (): Progress.ColumnDef<CacheMeta> => ({
   render: ({ task }) => task.metadata.phase,
 });
 
-const buildColumns = (): ReadonlyArray<Progress.ColumnDef<BuildMeta, any>> => [
+const buildColumns = (): ReadonlyArray<Progress.Column<BuildMeta>> => [
   Progress.Columns.description(),
   Progress.Columns.bar(),
   buildBranchColumn(),
@@ -72,7 +72,7 @@ const buildColumns = (): ReadonlyArray<Progress.ColumnDef<BuildMeta, any>> => [
   Progress.Columns.elapsed(),
 ];
 
-const migrationColumns = (): ReadonlyArray<Progress.ColumnDef<MigrationMeta, any>> => [
+const migrationColumns = (): ReadonlyArray<Progress.Column<MigrationMeta>> => [
   Progress.Columns.description(),
   Progress.Columns.bar(),
   migrationDatabaseColumn(),
@@ -81,7 +81,7 @@ const migrationColumns = (): ReadonlyArray<Progress.ColumnDef<MigrationMeta, any
   Progress.Columns.elapsed(),
 ];
 
-const cacheColumns = (): ReadonlyArray<Progress.ColumnDef<CacheMeta, any>> => [
+const cacheColumns = (): ReadonlyArray<Progress.Column<CacheMeta>> => [
   Progress.Columns.description(),
   Progress.Columns.bar(),
   cacheRegionColumn(),

--- a/src/columns.tsx
+++ b/src/columns.tsx
@@ -1,5 +1,5 @@
 import { Predicate } from "effect";
-import type { ColumnDef, ColumnSizeValue } from "./types";
+import type { Column, ColumnDef, ColumnSizeValue } from "./types";
 import {
   AmountCell,
   measureAmountLayout,
@@ -55,7 +55,7 @@ export const spacer = <M = unknown>({
   minWidth,
 });
 
-export const description = (): ColumnDef<any, DescriptionPrepared> => ({
+export const description = (): ColumnDef<unknown, DescriptionPrepared> => ({
   prepare: prepareDescription,
   flexShrink: 1,
   flexBasis: (prepared) => prepared.preferredWidth,
@@ -70,7 +70,7 @@ export const description = (): ColumnDef<any, DescriptionPrepared> => ({
   ),
 });
 
-export const bar = ({ size }: BarOptions = {}): ColumnDef<any, BarPrepared> => {
+export const bar = ({ size }: BarOptions = {}): ColumnDef<unknown, BarPrepared> => {
   const resolvedSize = resolveBarSize(size);
 
   return {
@@ -89,38 +89,33 @@ export const bar = ({ size }: BarOptions = {}): ColumnDef<any, BarPrepared> => {
   };
 };
 
-export const amount = (): ColumnDef<any, AmountLayout> => ({
+export const amount = (): ColumnDef<unknown, AmountLayout> => ({
   prepare: measureAmountLayout,
   align: "right",
   render: ({ task }, ctx) => <AmountCell task={task} layout={ctx.prepared} />,
 });
 
-export const elapsed = (): ColumnDef<any> => ({
+export const elapsed = (): ColumnDef<unknown> => ({
   align: "right",
   flexShrink: 0,
   render: ({ task }, ctx) => <ElapsedCell task={task} now={ctx.now} />,
 });
 
-export const elapsedEta = (): ColumnDef<any> => ({
+export const elapsedEta = (): ColumnDef<unknown> => ({
   align: "right",
   flexShrink: 0,
   minWidth: 11,
   render: ({ task }, ctx) => <ElapsedEtaCell task={task} now={ctx.now} />,
 });
 
-export const eta = (): ColumnDef<any> => ({
+export const eta = (): ColumnDef<unknown> => ({
   align: "right",
   flexShrink: 0,
   minWidth: 8,
   render: ({ task }) => <EtaCell task={task} />,
 });
 
-export const defaults = (): ReadonlyArray<ColumnDef<any, any>> => [
-  description(),
-  bar(),
-  amount(),
-  elapsedEta(),
-];
+export const defaults = (): ReadonlyArray<Column> => [description(), bar(), amount(), elapsedEta()];
 
 export const resolveColumnSizeValue = <P,>(
   value: ColumnSizeValue<P> | undefined,

--- a/src/services/renderer/column-resolver.ts
+++ b/src/services/renderer/column-resolver.ts
@@ -1,19 +1,12 @@
-import { resolveColumnSizeValue } from "../../columns";
 import { defaults } from "../../columns";
-import type { CellInfo, ColumnDef, TaskId } from "../../types";
+import type { Column, TaskId } from "../../types";
+import { prepareColumns, type ResolvedColumn } from "./column-runtime";
 import type { TaskRowModel } from "../store/types";
-
-type PrepareFn = NonNullable<ColumnDef<any, any>["prepare"]>;
-
-interface ResolvedColumnEntry {
-  readonly column: ColumnDef<any, any>;
-  readonly prepared: unknown;
-}
 
 export interface ResolvedColumnPosition {
   readonly index: number;
   readonly rows: ReadonlyArray<TaskRowModel>;
-  readonly entries: ReadonlyArray<ResolvedColumnEntry | undefined>;
+  readonly entries: ReadonlyArray<ResolvedColumn | undefined>;
   readonly flexGrow?: number;
   readonly flexShrink?: number;
   readonly flexBasis?: number;
@@ -24,8 +17,8 @@ const DEFAULT_COLUMNS = defaults();
 
 const getColumnsForRow = (
   row: TaskRowModel,
-  columns: ReadonlyMap<TaskId, ReadonlyArray<ColumnDef<any, any>>>,
-): ReadonlyArray<ColumnDef<any, any>> => columns.get(row.task.id) ?? DEFAULT_COLUMNS;
+  columns: ReadonlyMap<TaskId, ReadonlyArray<Column>>,
+): ReadonlyArray<Column> => columns.get(row.task.id) ?? DEFAULT_COLUMNS;
 
 const maxDefined = (values: ReadonlyArray<number | undefined>): number | undefined =>
   values.reduce<number | undefined>(
@@ -34,67 +27,19 @@ const maxDefined = (values: ReadonlyArray<number | undefined>): number | undefin
     undefined,
   );
 
-const resolvePreparedGroups = (
-  defs: ReadonlyArray<ColumnDef<any, any> | undefined>,
-  cellInfos: ReadonlyArray<CellInfo<unknown>>,
-): ReadonlyMap<PrepareFn, unknown> => {
-  const groupedRows = new Map<PrepareFn, CellInfo<any>[]>();
-
-  defs.forEach((def, rowIndex) => {
-    if (!def?.prepare) {
-      return;
-    }
-
-    const key = def.prepare;
-    const rows = groupedRows.get(key);
-    const cell = cellInfos[rowIndex];
-    if (!cell) {
-      return;
-    }
-
-    if (rows) {
-      rows.push(cell);
-    } else {
-      groupedRows.set(key, [cell]);
-    }
-  });
-
-  const groups = new Map<PrepareFn, unknown>();
-
-  for (const [key, rows] of groupedRows) {
-    groups.set(key, key(rows));
-  }
-
-  return groups;
-};
-
 export const resolveColumns = (
   rows: ReadonlyArray<TaskRowModel>,
-  columns: ReadonlyMap<TaskId, ReadonlyArray<ColumnDef<any, any>>>,
+  columns: ReadonlyMap<TaskId, ReadonlyArray<Column>>,
 ): ReadonlyArray<ResolvedColumnPosition> => {
   const columnsByRow = rows.map((row) => getColumnsForRow(row, columns));
   const maxColumnCount = columnsByRow.reduce((max, defs) => Math.max(max, defs.length), 0);
 
   return Array.from({ length: maxColumnCount }, (_, index) => {
     const defsAtIndex = columnsByRow.map((defs) => defs[index]);
-    const preparedGroups = resolvePreparedGroups(defsAtIndex, rows);
-    const entries = defsAtIndex.map((column) =>
-      column === undefined
-        ? undefined
-        : {
-            column,
-            prepared: column.prepare === undefined ? undefined : preparedGroups.get(column.prepare),
-          },
-    );
+    const entries = prepareColumns(defsAtIndex, rows);
 
     const resolveSize = (key: "flexGrow" | "flexShrink" | "flexBasis" | "minWidth") =>
-      maxDefined(
-        entries.map((entry) =>
-          entry === undefined
-            ? undefined
-            : resolveColumnSizeValue(entry.column[key], entry.prepared),
-        ),
-      );
+      maxDefined(entries.map((entry) => entry?.[key]));
 
     return {
       index,

--- a/src/services/renderer/column-runtime.ts
+++ b/src/services/renderer/column-runtime.ts
@@ -1,0 +1,56 @@
+import { resolveColumnSizeValue } from "../../columns";
+import type { CellInfo, Column, ColumnAlign, ColumnDef, ColumnRenderContext } from "../../types";
+import type { ReactNode } from "react";
+
+type PrepareFn = NonNullable<Column["prepare"]>;
+
+/** Prepared values never leave this boundary independently of their definition. */
+export interface ResolvedColumn {
+  readonly render: (cell: CellInfo, ctx: Omit<ColumnRenderContext, "prepared">) => ReactNode;
+  readonly align?: ColumnAlign;
+  readonly flexGrow?: number;
+  readonly flexShrink?: number;
+  readonly flexBasis?: number;
+  readonly minWidth?: number;
+}
+
+const bindColumn = <P>(column: ColumnDef<unknown, P>, prepared: P): ResolvedColumn => ({
+  render: (cell, ctx) => column.render(cell, { ...ctx, prepared }),
+  align: column.align,
+  flexGrow: resolveColumnSizeValue(column.flexGrow, prepared),
+  flexShrink: resolveColumnSizeValue(column.flexShrink, prepared),
+  flexBasis: resolveColumnSizeValue(column.flexBasis, prepared),
+  minWidth: resolveColumnSizeValue(column.minWidth, prepared),
+});
+
+/** Groups by prepare identity at one position, then binds each result to its original definition. */
+export const prepareColumns = (
+  definitions: ReadonlyArray<Column | undefined>,
+  cells: ReadonlyArray<CellInfo>,
+): ReadonlyArray<ResolvedColumn | undefined> => {
+  const groupedRows = new Map<PrepareFn, CellInfo[]>();
+  definitions.forEach((column, index) => {
+    if (!column?.prepare) {
+      return;
+    }
+    const cell = cells[index];
+    if (!cell) {
+      return;
+    }
+    const group = groupedRows.get(column.prepare);
+    if (group) {
+      group.push(cell);
+    } else {
+      groupedRows.set(column.prepare, [cell]);
+    }
+  });
+  const prepared = new Map<PrepareFn, unknown>();
+  for (const [prepare, rows] of groupedRows) {
+    prepared.set(prepare, prepare(rows));
+  }
+  return definitions.map((column) =>
+    column === undefined
+      ? undefined
+      : bindColumn(column, column.prepare === undefined ? undefined : prepared.get(column.prepare)),
+  );
+};

--- a/src/services/renderer/public-api.tsx
+++ b/src/services/renderer/public-api.tsx
@@ -2,7 +2,7 @@ import { Predicate } from "effect";
 import { Box, Text, useBoxMetrics, type DOMElement } from "ink";
 import type { ReactElement, ReactNode } from "react";
 import { useRef } from "react";
-import type { ColumnAlign, ColumnDef, TaskId } from "../../types";
+import type { ColumnAlign, Column, TaskId } from "../../types";
 import { useNow } from "./context/now-context";
 import { useSpinnerTick } from "./context/spinner-context";
 import { resolveColumns, type ResolvedColumnPosition } from "./column-resolver";
@@ -10,7 +10,7 @@ import type { TaskRowModel } from "../store/types";
 
 interface ProgressRendererProps {
   readonly rows: ReadonlyArray<TaskRowModel>;
-  readonly columns: ReadonlyMap<TaskId, ReadonlyArray<ColumnDef<any, any>>>;
+  readonly columns: ReadonlyMap<TaskId, ReadonlyArray<Column>>;
 }
 
 const justifyContentForAlign = (align: ColumnAlign | undefined) => {
@@ -47,15 +47,12 @@ const ColumnPosition = ({ position }: { readonly position: ResolvedColumnPositio
       minWidth={position.minWidth}
     >
       {position.rows.map((row, rowIndex) => {
-        const entry = position.entries[rowIndex];
-        const column = entry?.column;
-        const cell = row;
+        const column = position.entries[rowIndex];
         const output =
-          column?.render(cell, {
+          column?.render(row, {
             width: hasMeasured ? width : position.flexBasis,
             now,
             spinnerTick,
-            prepared: entry?.prepared,
           }) ?? null;
 
         return (

--- a/src/services/store/store.ts
+++ b/src/services/store/store.ts
@@ -1,7 +1,7 @@
 import { Clock, Context, Effect, Layer, Option, Queue } from "effect";
 import type {
   AddTaskOptions,
-  ColumnDef,
+  Column,
   TaskProgressSample,
   TaskId,
   TaskStore,
@@ -202,7 +202,7 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
   let state: TaskStore = {
     tasks: new Map<TaskId, TaskSnapshot>(),
     renderOrder: [],
-    columns: new Map<TaskId, ReadonlyArray<ColumnDef<any, any>>>(),
+    columns: new Map<TaskId, ReadonlyArray<Column>>(),
   };
   let publishedSnapshot = state;
   let hasPendingPublish = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,9 @@ export interface ColumnDef<M = unknown, P = void> {
   readonly minWidth?: ColumnSizeValue<P>;
 }
 
+/** Heterogeneous storage erases prepared types and, by default, metadata. Task options retain M. */
+export type Column<M = any> = ColumnDef<M, any>;
+
 /**
  * A typed facade over a single task created through the callback form of `task(...)`.
  *
@@ -96,7 +99,7 @@ export interface AddTaskOptions<M = void> {
   readonly parentId?: TaskId;
   readonly countDisplay?: TaskCountDisplay;
   readonly metadata?: M;
-  readonly columns?: ReadonlyArray<ColumnDef<M, any>>;
+  readonly columns?: ReadonlyArray<Column<M>>;
 }
 
 export interface UpdateTaskOptions {
@@ -150,7 +153,7 @@ export interface RenderRow {
 export interface TaskStore {
   readonly tasks: ReadonlyMap<TaskId, TaskSnapshot>;
   readonly renderOrder: ReadonlyArray<RenderRow>;
-  readonly columns: ReadonlyMap<TaskId, ReadonlyArray<ColumnDef<any, any>>>;
+  readonly columns: ReadonlyMap<TaskId, ReadonlyArray<Column>>;
 }
 
 /** Task operations shared by the progress service and its backing store. */

--- a/tests/column-runtime.test.ts
+++ b/tests/column-runtime.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import type { CellInfo, ColumnDef } from "../src/types";
+import { TaskId } from "../src/types";
+import { resolveColumns } from "../src/services/renderer/column-resolver";
+import { makeRows, makeTaskSnapshot } from "./helpers/renderer";
+
+test("shared preparation runs once per position and stays bound to each renderer and sizing hint", () => {
+  const calls: number[] = [];
+  const prepare = (cells: ReadonlyArray<CellInfo>) => {
+    calls.push(cells.length);
+    return { width: cells.length * 3 };
+  };
+  const left: ColumnDef<unknown, { width: number }> = {
+    prepare,
+    minWidth: (prepared) => prepared.width,
+    render: (_cell, { prepared, now }) => `left:${prepared.width}:${now}`,
+  };
+  const right: ColumnDef<unknown, { width: number }> = {
+    prepare,
+    minWidth: (prepared) => prepared.width + 1,
+    render: (_cell, { prepared, spinnerTick }) => `right:${prepared.width}:${spinnerTick}`,
+  };
+  const rows = makeRows([makeTaskSnapshot({ id: TaskId(1) }), makeTaskSnapshot({ id: TaskId(2) })]);
+  const positions = resolveColumns(
+    rows,
+    new Map([
+      [TaskId(1), [left, left]],
+      [TaskId(2), [right]],
+    ]),
+  );
+  expect(calls).toEqual([2, 1]);
+  expect(positions.map((position) => position.minWidth)).toEqual([7, 3]);
+  const context = { now: 123, spinnerTick: 4 };
+  expect(positions[0]!.entries[0]!.render(rows[0]!, context)).toBe("left:6:123");
+  expect(positions[0]!.entries[1]!.render(rows[1]!, context)).toBe("right:6:4");
+  expect(positions[1]!.entries[0]!.render(rows[0]!, context)).toBe("left:3:123");
+  expect(positions[1]!.entries[1]).toBeUndefined();
+  expect(calls).toEqual([2, 1]);
+});

--- a/tests/renderer-public-api.test.tsx
+++ b/tests/renderer-public-api.test.tsx
@@ -38,7 +38,7 @@ describe("renderer public api", () => {
   test("renders the combined elapsed/eta column while keeping standalone columns available", () => {
     const output = renderWithColumns(
       [deriveRow(makeTask(1, "timed-task"))],
-      new Map<Progress.TaskId, ReadonlyArray<Progress.ColumnDef<any, any>>>([
+      new Map<Progress.TaskId, ReadonlyArray<Progress.Column>>([
         [
           Progress.TaskId(1),
           [
@@ -68,7 +68,7 @@ describe("renderer public api", () => {
           }),
         ),
       ],
-      new Map<Progress.TaskId, ReadonlyArray<Progress.ColumnDef<any, any>>>([
+      new Map<Progress.TaskId, ReadonlyArray<Progress.Column>>([
         [Progress.TaskId(1), [Progress.Columns.description(), Progress.Columns.elapsedEta()]],
       ]),
       3_661_000,
@@ -89,7 +89,7 @@ describe("renderer public api", () => {
           }),
         ),
       ],
-      new Map<Progress.TaskId, ReadonlyArray<Progress.ColumnDef<any, any>>>([
+      new Map<Progress.TaskId, ReadonlyArray<Progress.Column>>([
         [Progress.TaskId(1), [Progress.Columns.description(), Progress.Columns.elapsedEta()]],
       ]),
       360_000_000,
@@ -146,7 +146,7 @@ describe("renderer public api", () => {
       readonly score: number;
     }
 
-    const columns = new Map<Progress.TaskId, ReadonlyArray<Progress.ColumnDef<any, any>>>([
+    const columns = new Map<Progress.TaskId, ReadonlyArray<Progress.Column>>([
       [
         Progress.TaskId(1),
         [
@@ -187,7 +187,7 @@ describe("renderer public api", () => {
   });
 
   test("renders empty cells when a task has fewer positional columns", () => {
-    const columns = new Map<Progress.TaskId, ReadonlyArray<Progress.ColumnDef<any, any>>>([
+    const columns = new Map<Progress.TaskId, ReadonlyArray<Progress.Column>>([
       [
         Progress.TaskId(1),
         [
@@ -213,7 +213,7 @@ describe("renderer public api", () => {
   });
 
   test("supports combining defaults with appended custom columns", () => {
-    const columns = new Map<Progress.TaskId, ReadonlyArray<Progress.ColumnDef<any, any>>>([
+    const columns = new Map<Progress.TaskId, ReadonlyArray<Progress.Column>>([
       [
         Progress.TaskId(1),
         [
@@ -252,7 +252,7 @@ describe("renderer public api", () => {
         deriveRow(makeTask(1, "task-a", { label: "alpha" })),
         deriveRow(makeTask(2, "task-b", { count: 7 })),
       ],
-      new Map<Progress.TaskId, ReadonlyArray<Progress.ColumnDef<any, any>>>([
+      new Map<Progress.TaskId, ReadonlyArray<Progress.Column>>([
         [Progress.TaskId(1), [Progress.Columns.description(), uppercase]],
         [Progress.TaskId(2), [Progress.Columns.description(), lengths]],
       ]),
@@ -265,7 +265,7 @@ describe("renderer public api", () => {
   test("aggregates numeric sizing hints across different columns at the same index", () => {
     const output = renderWithColumns(
       [deriveRow(makeTask(1, "wide-a")), deriveRow(makeTask(2, "wide-b"))],
-      new Map<Progress.TaskId, ReadonlyArray<Progress.ColumnDef<any, any>>>([
+      new Map<Progress.TaskId, ReadonlyArray<Progress.Column>>([
         [
           Progress.TaskId(1),
           [


### PR DESCRIPTION
Column resolution now binds prepared data and sizing hints to each column before React renders it. Heterogeneous definition storage uses a single `Column<M>` alias, while authoring still uses `ColumnDef<M, P>`.

**Problem and before example**

Resolved entries previously carried the original definition and an independently stored `unknown` prepared value. React reassembled them for every cell:

```ts
const column = entry?.column;
column?.render(cell, {
  width, now, spinnerTick,
  prepared: entry?.prepared,
});
```

`ColumnDef<any, any>` was repeated across storage, resolution, and rendering, and the renderer had to know how prepared values were paired with definitions.

**Solution and after example**

The preparation boundary groups rows by prepare-function identity at each position, then captures the matching prepared value and resolves numeric sizing once:

```ts
const bindColumn = <P>(column: ColumnDef<unknown, P>, prepared: P) => ({
  render: (cell, ctx) => column.render(cell, { ...ctx, prepared }),
  // Alignment and resolved numeric sizing accompany the bound callback.
});
```

React consumes the bound entry directly:

```ts
column?.render(row, { width, now, spinnerTick });
```

Custom column objects remain compatible. Use `ColumnDef<Metadata, Prepared>` for individual definitions and `ReadonlyArray<Column<Metadata>>` for heterogeneous lists. The new alias deliberately retains type erasure at storage; this does not claim to eliminate all `any` or add runtime metadata validation. Built-ins now use `unknown` metadata.

The benchmark inspects rendered output instead of exposing private prepared values. README and mixed-column examples describe the list alias.

**Validation**

- `bun run check` passes: typechecking, lint, formatting, and Knip.
- `bun test`: 126 passing tests. A new case covers shared preparation once per position, different callbacks using the shared result, dynamic sizing, sparse columns, and time/spinner context.
- `bun run bench` passes all correctness assertions.
- All four refactors apply together without conflicts and pass the combined check/test suite.

Independent PR targeting `main`.
