### PR TITLE
perf: memoize unchanged cells and evaluate rendering costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,13 @@ Use `ColumnDef<M, P>` to author a column with typed metadata and prepared data, 
 `Column<M>` for a list containing columns with different prepared types. The renderer
 binds each prepared value to its definition before rendering cells.
 
+Treat task data, column definitions, and prepared values as immutable. Unchanged
+cells are memoized by row, measured width, definition identity, and prepared-value
+identity. Reuse column definitions; return a stable prepared value when its meaning
+has not changed if you want custom render callbacks to be skipped. A newly allocated
+prepared object safely rerenders its cells. Built-in React cells also memoize their
+individual display inputs, so equivalent layout values do not redo their output.
+
 If a task does not provide `columns`, the renderer falls back to `Progress.Columns.defaults()`.
 
 ### Clock hooks for custom cells

--- a/benchmarks/rendering/cell-memoization.json
+++ b/benchmarks/rendering/cell-memoization.json
@@ -1,0 +1,231 @@
+{
+  "clockHooksRevision": "1b39190",
+  "memoizationRevision": "241c3cd",
+  "aggregation": "Median of 14 samples per scenario per revision: two runs, each with two warmup rounds and seven measured rounds.",
+  "clockHooksRuns": [
+    {
+      "runtime": {
+        "bun": "1.3.13",
+        "platform": "darwin",
+        "arch": "arm64"
+      },
+      "rows": 100,
+      "framesPerSample": 30,
+      "warmupRounds": 2,
+      "measuredRounds": 7,
+      "results": [
+        {
+          "scenario": "spinner-all",
+          "medianMillis": 955.7917910000001,
+          "samplesMillis": [
+            955.7917910000001, 961.30825, 967.5454169999994, 953.9214169999996, 979.6018749999994,
+            955.1399590000001, 951.0802909999993
+          ],
+          "columnRenderCallsPerSample": [0, 0, 0, 0, 0, 0, 0]
+        },
+        {
+          "scenario": "spinner-one",
+          "medianMillis": 951.3297500000008,
+          "samplesMillis": [
+            951.3297500000008, 952.4219580000008, 941.7520829999994, 944.3051669999986,
+            968.0283749999999, 972.6469169999982, 944.364625000002
+          ],
+          "columnRenderCallsPerSample": [0, 0, 0, 0, 0, 0, 0]
+        },
+        {
+          "scenario": "now-one",
+          "medianMillis": 958.713375000003,
+          "samplesMillis": [
+            963.9906659999979, 953.1719999999987, 962.8104170000006, 947.0042079999985,
+            938.9762919999994, 960.1231660000012, 958.713375000003
+          ],
+          "columnRenderCallsPerSample": [0, 0, 0, 0, 0, 0, 0]
+        },
+        {
+          "scenario": "task-one",
+          "medianMillis": 1117.7742079999953,
+          "samplesMillis": [
+            1104.431708, 1123.7586249999986, 1118.132207999999, 1106.3062910000008,
+            1109.9721660000068, 1129.421000000002, 1117.7742079999953
+          ],
+          "columnRenderCallsPerSample": [18000, 18000, 18000, 18000, 18000, 18000, 18000]
+        }
+      ]
+    },
+    {
+      "runtime": {
+        "bun": "1.3.13",
+        "platform": "darwin",
+        "arch": "arm64"
+      },
+      "rows": 100,
+      "framesPerSample": 30,
+      "warmupRounds": 2,
+      "measuredRounds": 7,
+      "results": [
+        {
+          "scenario": "spinner-all",
+          "medianMillis": 981.711542,
+          "samplesMillis": [
+            973.218042, 981.711542, 960.4772909999992, 987.3855410000006, 952.4206249999997,
+            1092.7543750000004, 1161.9717499999988
+          ],
+          "columnRenderCallsPerSample": [0, 0, 0, 0, 0, 0, 0]
+        },
+        {
+          "scenario": "spinner-one",
+          "medianMillis": 983.8924160000006,
+          "samplesMillis": [
+            1014.6374580000011, 964.3522919999996, 983.8924160000006, 949.178750000001,
+            1004.8261670000011, 1043.6292499999981, 973.9595410000002
+          ],
+          "columnRenderCallsPerSample": [0, 0, 0, 0, 0, 0, 0]
+        },
+        {
+          "scenario": "now-one",
+          "medianMillis": 1043.0403750000005,
+          "samplesMillis": [
+            1043.0403750000005, 1042.6835000000028, 1022.5416669999977, 1059.0115829999995,
+            1028.3697090000023, 1069.0805, 1106.2597920000007
+          ],
+          "columnRenderCallsPerSample": [0, 0, 0, 0, 0, 0, 0]
+        },
+        {
+          "scenario": "task-one",
+          "medianMillis": 1170.6705000000002,
+          "samplesMillis": [
+            1184.2417910000004, 1153.3891250000015, 1238.127708, 1259.7919580000016,
+            1131.6409170000043, 1152.2903329999972, 1170.6705000000002
+          ],
+          "columnRenderCallsPerSample": [18000, 18000, 18000, 18000, 18000, 18000, 18000]
+        }
+      ]
+    }
+  ],
+  "memoizationRuns": [
+    {
+      "runtime": {
+        "bun": "1.3.13",
+        "platform": "darwin",
+        "arch": "arm64"
+      },
+      "rows": 100,
+      "framesPerSample": 30,
+      "warmupRounds": 2,
+      "measuredRounds": 7,
+      "results": [
+        {
+          "scenario": "spinner-all",
+          "medianMillis": 972.2866249999997,
+          "samplesMillis": [
+            969.8235829999999, 971.0992080000001, 985.3139580000006, 972.2866249999997, 975.931458,
+            987.8292080000001, 961.1371669999999
+          ],
+          "columnRenderCallsPerSample": [0, 0, 0, 0, 0, 0, 0]
+        },
+        {
+          "scenario": "spinner-one",
+          "medianMillis": 1002.2337919999991,
+          "samplesMillis": [
+            975.2270000000008, 960.6929999999993, 974.5767080000005, 1002.2337919999991,
+            1065.689375, 1062.1150000000016, 1052.6526249999988
+          ],
+          "columnRenderCallsPerSample": [0, 0, 0, 0, 0, 0, 0]
+        },
+        {
+          "scenario": "now-one",
+          "medianMillis": 1013.5213330000006,
+          "samplesMillis": [
+            1026.4180829999968, 1016.1840420000008, 1105.135542, 1013.5213330000006,
+            984.8736250000002, 1002.5410840000004, 980.070083999999
+          ],
+          "columnRenderCallsPerSample": [0, 0, 0, 0, 0, 0, 0]
+        },
+        {
+          "scenario": "task-one",
+          "medianMillis": 1089.312291000002,
+          "samplesMillis": [
+            1059.4134589999994, 1089.3837079999976, 1143.194875000001, 1056.237165999999,
+            1092.9467919999952, 1074.7106249999997, 1089.312291000002
+          ],
+          "columnRenderCallsPerSample": [9030, 9030, 9030, 9030, 9030, 9030, 9030]
+        }
+      ]
+    },
+    {
+      "runtime": {
+        "bun": "1.3.13",
+        "platform": "darwin",
+        "arch": "arm64"
+      },
+      "rows": 100,
+      "framesPerSample": 30,
+      "warmupRounds": 2,
+      "measuredRounds": 7,
+      "results": [
+        {
+          "scenario": "spinner-all",
+          "medianMillis": 1018.5161659999994,
+          "samplesMillis": [
+            992.6430829999999, 999.7930409999994, 1020.0388329999996, 1032.4638340000001,
+            1077.980541, 1018.5161659999994, 953.7786669999987
+          ],
+          "columnRenderCallsPerSample": [0, 0, 0, 0, 0, 0, 0]
+        },
+        {
+          "scenario": "spinner-one",
+          "medianMillis": 1013.3149999999987,
+          "samplesMillis": [
+            1040.4370419999996, 974.5537499999991, 982.1843749999989, 1032.2165839999998,
+            1069.8762920000008, 1013.3149999999987, 1005.3494580000006
+          ],
+          "columnRenderCallsPerSample": [0, 0, 0, 0, 0, 0, 0]
+        },
+        {
+          "scenario": "now-one",
+          "medianMillis": 1027.7221250000002,
+          "samplesMillis": [
+            1006.2089169999999, 1031.403875, 1027.7221250000002, 1065.8286659999976,
+            1057.3864170000015, 995.5487909999974, 964.9621249999982
+          ],
+          "columnRenderCallsPerSample": [0, 0, 0, 0, 0, 0, 0]
+        },
+        {
+          "scenario": "task-one",
+          "medianMillis": 1173.5591249999998,
+          "samplesMillis": [
+            1173.5591249999998, 1170.9346670000014, 1176.0594999999994, 1184.575874999995,
+            1185.7877080000035, 1153.9631660000014, 1141.245084000002
+          ],
+          "columnRenderCallsPerSample": [9030, 9030, 9030, 9030, 9030, 9030, 9030]
+        }
+      ]
+    }
+  ],
+  "comparison": [
+    {
+      "scenario": "spinner-all",
+      "clockHooksMedianMillis": 964.4268334999997,
+      "memoizationMedianMillis": 986.5715830000004,
+      "timeReductionPercent": -2.296156507760694
+    },
+    {
+      "scenario": "spinner-one",
+      "clockHooksMedianMillis": 966.1903334999997,
+      "memoizationMedianMillis": 1009.3322289999996,
+      "timeReductionPercent": -4.465154949720884
+    },
+    {
+      "scenario": "now-one",
+      "clockHooksMedianMillis": 993.2661664999978,
+      "memoizationMedianMillis": 1014.8526875000007,
+      "timeReductionPercent": -2.173286650452222
+    },
+    {
+      "scenario": "task-one",
+      "clockHooksMedianMillis": 1130.5309585000032,
+      "memoizationMedianMillis": 1142.2199795000015,
+      "timeReductionPercent": -1.0339408144565354
+    }
+  ]
+}

--- a/src/columns.tsx
+++ b/src/columns.tsx
@@ -87,7 +87,7 @@ export const bar = ({ size }: BarOptions = {}): ColumnDef<unknown, BarPrepared> 
 export const amount = (): ColumnDef<unknown, AmountLayout> => ({
   prepare: measureAmountLayout,
   align: "right",
-  render: ({ task }, ctx) => <AmountCell task={task} layout={ctx.prepared} />,
+  render: ({ task }, ctx) => <AmountCell task={task} {...ctx.prepared} />,
 });
 
 export const elapsed = (): ColumnDef<unknown> => ({

--- a/src/services/renderer/column-runtime.ts
+++ b/src/services/renderer/column-runtime.ts
@@ -6,6 +6,9 @@ type PrepareFn = NonNullable<Column["prepare"]>;
 
 /** Prepared values never leave this boundary independently of their definition. */
 export interface ResolvedColumn {
+  /** Identity inputs let cells compare bindings without comparing freshly allocated closures. */
+  readonly definition: Column;
+  readonly prepared: unknown;
   readonly render: (cell: CellInfo, ctx: Omit<ColumnRenderContext, "prepared">) => ReactNode;
   readonly align?: ColumnAlign;
   readonly flexGrow?: number;
@@ -15,6 +18,8 @@ export interface ResolvedColumn {
 }
 
 const bindColumn = <P>(column: ColumnDef<unknown, P>, prepared: P): ResolvedColumn => ({
+  definition: column,
+  prepared,
   render: (cell, ctx) => column.render(cell, { ...ctx, prepared }),
   align: column.align,
   flexGrow: resolveColumnSizeValue(column.flexGrow, prepared),

--- a/src/services/renderer/columns/amount-column.tsx
+++ b/src/services/renderer/columns/amount-column.tsx
@@ -1,4 +1,5 @@
 import { Text } from "ink";
+import { memo } from "react";
 import type { CellInfo, TaskSnapshot } from "../../../types";
 import { getAmountParts } from "../shared/amount-parts";
 import { textWidth } from "../shared/text-width";
@@ -80,14 +81,10 @@ const AmountValue = ({
   );
 };
 
-export const AmountCell = ({
-  task,
-  layout,
-}: {
-  readonly task: TaskSnapshot;
-  readonly layout: AmountLayout;
-}) => (
-  <Text wrap="truncate-end">
-    <AmountValue task={task} layout={layout} />
-  </Text>
+export const AmountCell = memo(
+  ({ task, ...layout }: { readonly task: TaskSnapshot } & AmountLayout) => (
+    <Text wrap="truncate-end">
+      <AmountValue task={task} layout={layout} />
+    </Text>
+  ),
 );

--- a/src/services/renderer/columns/bar-column.tsx
+++ b/src/services/renderer/columns/bar-column.tsx
@@ -1,4 +1,5 @@
 import { Text } from "ink";
+import { memo } from "react";
 import type { CellInfo } from "../../../types";
 import { isDeterminate } from "../shared/determinate";
 import type { TaskRowModel } from "../../store/types";
@@ -47,14 +48,10 @@ const ProgressBarSegments = ({
   );
 };
 
-export const BarCell = ({
-  task,
-  width,
-}: {
-  readonly task: TaskRowModel["task"];
-  readonly width?: number;
-}) => (
-  <Text wrap="truncate-end">
-    <ProgressBarSegments task={task} width={width ?? 0} />
-  </Text>
+export const BarCell = memo(
+  ({ task, width }: { readonly task: TaskRowModel["task"]; readonly width?: number }) => (
+    <Text wrap="truncate-end">
+      <ProgressBarSegments task={task} width={width ?? 0} />
+    </Text>
+  ),
 );

--- a/src/services/renderer/columns/description-column.tsx
+++ b/src/services/renderer/columns/description-column.tsx
@@ -1,5 +1,6 @@
 import cliSpinners, { type SpinnerName } from "cli-spinners";
 import { Text } from "ink";
+import { memo } from "react";
 import type { CellInfo, TaskSnapshot } from "../../../types";
 import { useSpinnerTick } from "../context/spinner-context";
 import { isDeterminate } from "../shared/determinate";
@@ -85,35 +86,37 @@ const TaskIndicatorGlyph = ({
   return <Text color={indicator.color}>{indicator.symbol}</Text>;
 };
 
-export const DescriptionCell = ({
-  cell,
-  width,
-  minTreeWidth,
-}: {
-  readonly cell: CellInfo<unknown>;
-  readonly width: number | undefined;
-  readonly minTreeWidth: number;
-}) => {
-  const showTree = width === undefined || width >= minTreeWidth;
-  const treePrefix = showTree ? cell.derived.treePrefix : "";
+export const DescriptionCell = memo(
+  ({
+    cell,
+    width,
+    minTreeWidth,
+  }: {
+    readonly cell: CellInfo<unknown>;
+    readonly width: number | undefined;
+    readonly minTreeWidth: number;
+  }) => {
+    const showTree = width === undefined || width >= minTreeWidth;
+    const treePrefix = showTree ? cell.derived.treePrefix : "";
 
-  if (!showTree && width !== undefined && width <= 1) {
-    return <TaskIndicatorGlyph task={cell.task} />;
-  }
+    if (!showTree && width !== undefined && width <= 1) {
+      return <TaskIndicatorGlyph task={cell.task} />;
+    }
 
-  if (!showTree && width !== undefined && width === 2) {
+    if (!showTree && width !== undefined && width === 2) {
+      return (
+        <Text wrap="truncate-end">
+          <TaskIndicatorGlyph task={cell.task} />…
+        </Text>
+      );
+    }
+
     return (
       <Text wrap="truncate-end">
-        <TaskIndicatorGlyph task={cell.task} />…
+        {treePrefix}
+        <TaskIndicatorGlyph task={cell.task} />
+        {` ${cell.task.description}`}
       </Text>
     );
-  }
-
-  return (
-    <Text wrap="truncate-end">
-      {treePrefix}
-      <TaskIndicatorGlyph task={cell.task} />
-      {` ${cell.task.description}`}
-    </Text>
-  );
-};
+  },
+);

--- a/src/services/renderer/columns/elapsed-column.tsx
+++ b/src/services/renderer/columns/elapsed-column.tsx
@@ -1,13 +1,14 @@
 import { Text } from "ink";
+import { memo } from "react";
 import { formatElapsed } from "../shared/format";
 import { useNow } from "../context/now-context";
 import type { TaskRowModel } from "../../store/types";
 
-export const ElapsedCell = ({ task }: { readonly task: TaskRowModel["task"] }) => {
+export const ElapsedCell = memo(({ task }: { readonly task: TaskRowModel["task"] }) => {
   const now = useNow(task.status === "running");
   return (
     <Text wrap="truncate-end" color="gray">
       {formatElapsed(task, now)}
     </Text>
   );
-};
+});

--- a/src/services/renderer/columns/elapsed-eta-column.tsx
+++ b/src/services/renderer/columns/elapsed-eta-column.tsx
@@ -1,13 +1,14 @@
 import { Text } from "ink";
+import { memo } from "react";
 import { formatElapsedEta } from "../shared/format";
 import { useNow } from "../context/now-context";
 import type { TaskRowModel } from "../../store/types";
 
-export const ElapsedEtaCell = ({ task }: { readonly task: TaskRowModel["task"] }) => {
+export const ElapsedEtaCell = memo(({ task }: { readonly task: TaskRowModel["task"] }) => {
   const now = useNow(task.status === "running");
   return (
     <Text wrap="truncate-end" color="gray">
       {formatElapsedEta(task, now)}
     </Text>
   );
-};
+});

--- a/src/services/renderer/columns/eta-column.tsx
+++ b/src/services/renderer/columns/eta-column.tsx
@@ -1,8 +1,9 @@
 import { Text } from "ink";
+import { memo } from "react";
 import { formatEta } from "../shared/format";
 import type { TaskRowModel } from "../../store/types";
 
-export const EtaCell = ({ task }: { readonly task: TaskRowModel["task"] }) => {
+export const EtaCell = memo(({ task }: { readonly task: TaskRowModel["task"] }) => {
   const eta = formatEta(task);
 
   if (eta === "") {
@@ -14,4 +15,4 @@ export const EtaCell = ({ task }: { readonly task: TaskRowModel["task"] }) => {
       {`ETA: ${eta}`}
     </Text>
   );
-};
+});

--- a/src/services/renderer/public-api.tsx
+++ b/src/services/renderer/public-api.tsx
@@ -1,9 +1,10 @@
 import { Predicate } from "effect";
 import { Box, Text, useBoxMetrics, type DOMElement } from "ink";
 import type { ReactElement, ReactNode } from "react";
-import { useRef } from "react";
+import { memo, useRef } from "react";
 import type { ColumnAlign, Column, TaskId } from "../../types";
 import { resolveColumns, type ResolvedColumnPosition } from "./column-resolver";
+import type { ResolvedColumn } from "./column-runtime";
 import type { TaskRowModel } from "../store/types";
 
 interface ProgressRendererProps {
@@ -29,6 +30,25 @@ const RenderedNode = ({ node }: { readonly node: ReactNode }) => {
   return node;
 };
 
+interface ColumnCellProps {
+  readonly row: TaskRowModel;
+  readonly column: ResolvedColumn | undefined;
+  readonly width: number | undefined;
+}
+
+const ColumnCell = memo(
+  ({ row, column, width }: ColumnCellProps) => (
+    <Box height={1} justifyContent={justifyContentForAlign(column?.align)}>
+      <RenderedNode node={column?.render(row, { width }) ?? null} />
+    </Box>
+  ),
+  (previous, next) =>
+    previous.row === next.row &&
+    previous.width === next.width &&
+    previous.column?.definition === next.column?.definition &&
+    Object.is(previous.column?.prepared, next.column?.prepared),
+);
+
 const ColumnPosition = ({ position }: { readonly position: ResolvedColumnPosition }) => {
   const ref = useRef<DOMElement>(null!);
   const { width, hasMeasured } = useBoxMetrics(ref);
@@ -42,19 +62,14 @@ const ColumnPosition = ({ position }: { readonly position: ResolvedColumnPositio
       flexBasis={position.flexBasis}
       minWidth={position.minWidth}
     >
-      {position.rows.map((row, rowIndex) => {
-        const column = position.entries[rowIndex];
-        const output =
-          column?.render(row, {
-            width: hasMeasured ? width : position.flexBasis,
-          }) ?? null;
-
-        return (
-          <Box key={row.task.id} height={1} justifyContent={justifyContentForAlign(column?.align)}>
-            <RenderedNode node={output} />
-          </Box>
-        );
-      })}
+      {position.rows.map((row, rowIndex) => (
+        <ColumnCell
+          key={row.task.id}
+          row={row}
+          column={position.entries[rowIndex]}
+          width={hasMeasured ? width : position.flexBasis}
+        />
+      ))}
     </Box>
   );
 };

--- a/tests/renderer-memoization.test.tsx
+++ b/tests/renderer-memoization.test.tsx
@@ -1,0 +1,124 @@
+import { expect, onTestFinished, test } from "bun:test";
+import { Box, render } from "ink";
+import stripAnsi from "strip-ansi";
+import { Columns, TaskId, type Column, type ColumnDef } from "../src";
+import { ProgressRenderer } from "../src/services/renderer/public-api";
+import { toRenderSnapshot } from "../src/services/store/render-snapshot";
+import { createMockStdio } from "./helpers/mock-stdio";
+import { makeTaskSnapshot, renderRows } from "./helpers/renderer";
+
+const setup = async (definitions: ReadonlyArray<Column>, width = 80) => {
+  const tasks = new Map([1, 2].map((id) => [TaskId(id), makeTaskSnapshot({ id: TaskId(id) })]));
+  const store = {
+    tasks,
+    renderOrder: Array.from(tasks.keys(), (id) => ({ id, depth: 0 })),
+    columns: new Map(Array.from(tasks.keys(), (id) => [id, definitions])),
+  };
+  let snapshot = toRenderSnapshot(store);
+  const tree = (width: number) => (
+    <Box width={width}>
+      <ProgressRenderer rows={snapshot.rows} columns={store.columns} />
+    </Box>
+  );
+  const io = createMockStdio({ stdout: { isTTY: true, columns: 80, rows: 24 } });
+  const instance = render(tree(width), {
+    stdout: io.service.stdout,
+    patchConsole: false,
+    exitOnCtrlC: false,
+    debug: true,
+  });
+  onTestFinished(() => instance.unmount());
+  await instance.waitUntilRenderFlush();
+  return {
+    store,
+    increment: () => {
+      const task = tasks.get(TaskId(1))!;
+      tasks.set(task.id, {
+        ...task,
+        units: {
+          ...task.units,
+          succeeded: task.units.succeeded + 1,
+          processed: task.units.processed + 1,
+        },
+      });
+    },
+    update: async (nextWidth = width) => {
+      snapshot = toRenderSnapshot(store, snapshot);
+      io.stdout.clear();
+      instance.rerender(tree(nextWidth));
+      await instance.waitUntilRenderFlush();
+      return { output: stripAnsi(io.stdout.getOutput()), rows: snapshot.rows };
+    },
+  };
+};
+
+test("unchanged rows skip column callbacks while changed rows and definitions update", async () => {
+  const calls = new Map<TaskId, number>();
+  const column: Column = {
+    flexBasis: 10,
+    render: ({ task }) => {
+      calls.set(task.id, (calls.get(task.id) ?? 0) + 1);
+      return `count:${task.units.processed}`;
+    },
+  };
+  const fixture = await setup([column]);
+  const before = new Map(calls);
+  fixture.increment();
+  const { output } = await fixture.update();
+  expect(calls.get(TaskId(1))).toBe(before.get(TaskId(1))! + 1);
+  expect(calls.get(TaskId(2))).toBe(before.get(TaskId(2)));
+  expect(output).toContain("count:2");
+  expect(output).toContain("count:1");
+
+  fixture.store.columns.set(TaskId(2), [{ ...column, render: () => "changed" }]);
+  expect((await fixture.update()).output).toContain("changed");
+});
+
+test("changed shared preparation invalidates unchanged rows", async () => {
+  const seen = new Map<TaskId, number>();
+  const column: ColumnDef<unknown, number> = {
+    flexBasis: 20,
+    prepare: (rows) => rows.reduce((sum, row) => sum + row.task.units.processed, 0),
+    render: ({ task }, { prepared }) => {
+      seen.set(task.id, prepared);
+      return `sum:${prepared}`;
+    },
+  };
+  const fixture = await setup([column]);
+  fixture.increment();
+  await fixture.update();
+  expect(seen.get(TaskId(1))).toBe(3);
+  expect(seen.get(TaskId(2))).toBe(3);
+});
+
+test("measured width changes reach memoized cells", async () => {
+  const widths = new Map<TaskId, number | undefined>();
+  const column: Column = {
+    flexBasis: 60,
+    flexShrink: 1,
+    render: ({ task }, { width }) => {
+      widths.set(task.id, width);
+      return "x".repeat(60);
+    },
+  };
+  const fixture = await setup([column], 40);
+  expect(widths.get(TaskId(1))).toBe(40);
+  await fixture.update(20);
+  expect(widths.get(TaskId(1))).toBe(20);
+  expect(widths.get(TaskId(2))).toBe(20);
+});
+
+test("amount cells keep shared alignment when another row crosses a digit boundary", async () => {
+  const definitions = [Columns.amount()];
+  const fixture = await setup(definitions);
+  const task = fixture.store.tasks.get(TaskId(1))!;
+  fixture.store.tasks.set(task.id, {
+    ...task,
+    units: { succeeded: 9, failed: 0, processed: 9, total: 9 },
+  });
+  await fixture.update();
+  fixture.increment();
+  const { output, rows } = await fixture.update();
+  const expected = renderRows(rows, { columns: fixture.store.columns });
+  expect(output).toContain(expected);
+});


### PR DESCRIPTION
Updating one task currently reruns every column callback and built-in cell. Memoize column cells by row, measured width, original definition, and prepared-value identity. Memoize built-in output separately using stable display inputs; amount layout fields are passed as individual props so equivalent prepared objects can skip that component's work.

Stacked on #52; base is `perf/clock-hooks`. Merge/rebase the clock-hooks change first.

### Benchmark finding: no demonstrated rendering-time gain

This PR is a draft because the default-column workload does not show a consistent elapsed-time benefit. Column callbacks for a 30-frame single-task-update sample fall from 18,000 to 9,030 (49.8% fewer), but Ink layout/output and memoization overhead leave total rendering time roughly unchanged or slightly worse. I do not recommend merging this as a performance improvement based on these measurements.

Identical `bun run bench:render` harness from #52: Bun 1.3.13 / macOS arm64, 100 rows, four default columns, 30 frames per sample, two warmups and seven measured samples per run. Two runs per revision; table pools all 14 samples per scenario. Both revisions ran sequentially without concurrent checks. Debug output goes to a sink; timings include React/Ink reconciliation, layout, output generation and flush, plus snapshot derivation for task updates. They exclude physical terminal latency, timer delays, and store publication.

| Scenario | Clock hooks | With memoization | Time reduction |
|---|---:|---:|---:|
| spinner-all | 964.4 ms | 986.6 ms | -2.3% |
| spinner-one | 966.2 ms | 1009.3 ms | -4.5% |
| now-one | 993.3 ms | 1014.9 ms | -2.2% |
| task-one | 1130.5 ms | 1142.2 ms | -1.0% |

Negative reductions mean slower. Single-task medians varied between runs (memoization: 1089.3 / 1173.6 ms; clock hooks: 1117.8 / 1170.7 ms), so the small elapsed-time difference is not a reliable speedup. Clock-only samples still invoke zero column callbacks. All raw samples are in `benchmarks/rendering/cell-memoization.json`; the harness is unchanged from #52.

### Correctness and validation

Prepared values remain paired with their definition; identity comparison does not deep-compare arbitrary user data. Newly allocated prepared objects rerender custom cells. Context and component state updates still work through the memo boundary. README describes the immutable input contract.

- `bun run format`
- `bun run check` (typecheck, lint, format check, knip)
- `bun test`: 134 passed
- Mounted tests cover unchanged-row callback skipping, changed column definitions, shared preparation changes, measured width changes, and amount alignment crossing a digit boundary. Clock unsubscribe/resume tests also pass with memoization.
