### PR TITLE
refactor: keep ETA sampling and estimation together

### DIFF
--- a/src/progress-estimation.ts
+++ b/src/progress-estimation.ts
@@ -1,0 +1,74 @@
+import type { TaskProgressSample, TaskSnapshot } from "./task-model";
+
+const ETA_SAMPLE_WINDOW_MILLIS = 30_000;
+const ETA_SAMPLE_MAX_LENGTH = 1_000;
+
+/**
+ * Returns a new progress sample deque with the latest processed count appended.
+ *
+ * Samples are retained for the ETA rolling window and capped by count so very chatty tasks do not
+ * grow memory without bound.
+ */
+export const appendProgressSample = (
+  samples: ReadonlyArray<TaskProgressSample> | undefined,
+  now: number,
+  processed: number,
+): ReadonlyArray<TaskProgressSample> => {
+  const previousSamples = samples ?? [];
+  const lastSample = previousSamples.at(-1);
+  if (lastSample?.processed === processed) {
+    return previousSamples;
+  }
+
+  // Keep one sample immediately before the rolling window when possible. That gives the ETA
+  // calculation a usable delta even just after old samples age out of the 30s window.
+  const windowStart = now - ETA_SAMPLE_WINDOW_MILLIS;
+  const appendedLength = previousSamples.length + 1;
+  let firstRetainedIndex = Math.max(0, appendedLength - ETA_SAMPLE_MAX_LENGTH);
+  while (
+    firstRetainedIndex + 1 < previousSamples.length &&
+    previousSamples[firstRetainedIndex + 1]!.timestamp < windowStart
+  ) {
+    firstRetainedIndex++;
+  }
+
+  return [...previousSamples.slice(firstRetainedIndex), { timestamp: now, processed }];
+};
+
+/**
+ * Estimates remaining time from the task's retained progress sample deque.
+ *
+ * Returns undefined for inactive or unknown-total tasks, no remaining work, or insufficient
+ * observations with positive processed and time deltas.
+ */
+export const estimateRemainingMillis = (task: TaskSnapshot): number | undefined => {
+  const { processed, total } = task.units;
+  if (task.status !== "running" || total === undefined) {
+    return undefined;
+  }
+
+  const remaining = total - processed;
+  if (processed <= 0 || remaining <= 0) {
+    return undefined;
+  }
+
+  const samples = task.progressSamples;
+  const lastSample = samples.at(-1);
+  if (lastSample === undefined) {
+    return undefined;
+  }
+
+  const firstSample = samples[0];
+  if (firstSample === undefined || firstSample === lastSample) {
+    return undefined;
+  }
+
+  // appendProgressSample retains the rolling window, so these endpoints measure recent throughput.
+  const deltaProcessed = lastSample.processed - firstSample.processed;
+  const deltaMillis = lastSample.timestamp - firstSample.timestamp;
+  if (deltaProcessed <= 0 || deltaMillis <= 0) {
+    return undefined;
+  }
+
+  return Math.max(0, Math.floor((remaining * deltaMillis) / deltaProcessed));
+};

--- a/src/renderer/shared/format.ts
+++ b/src/renderer/shared/format.ts
@@ -1,5 +1,5 @@
 import type { TaskSnapshot } from "../../task-model";
-import { isDeterminate } from "./determinate";
+import { estimateRemainingMillis } from "../../progress-estimation";
 import { getAmountParts } from "./amount-parts";
 
 const formatDurationSeconds = (seconds: number): string => {
@@ -27,42 +27,6 @@ const formatClockDurationSeconds = (seconds: number): string => {
   return hours > 0 ? `${`${hours}`.padStart(2, "0")}:${clock}` : clock;
 };
 
-/**
- * Estimates remaining time from the task's retained progress sample deque.
- *
- * Returns undefined until there are at least two samples with positive processed and time deltas.
- */
-const getSmoothedEtaMillis = (
-  task: TaskSnapshot & { readonly units: TaskSnapshot["units"] & { readonly total: number } },
-): number | undefined => {
-  const { processed, total } = task.units;
-  const remaining = total - processed;
-  if (processed <= 0 || remaining <= 0) {
-    return undefined;
-  }
-
-  const samples = task.progressSamples;
-  const lastSample = samples.at(-1);
-  if (lastSample === undefined) {
-    return undefined;
-  }
-
-  const firstSample = samples[0];
-  if (firstSample === undefined || firstSample === lastSample) {
-    return undefined;
-  }
-
-  // The store maintains this as a retained rolling deque, so the first and last samples represent
-  // recent throughput rather than lifetime average throughput.
-  const deltaProcessed = lastSample.processed - firstSample.processed;
-  const deltaMillis = lastSample.timestamp - firstSample.timestamp;
-  if (deltaProcessed <= 0 || deltaMillis <= 0) {
-    return undefined;
-  }
-
-  return Math.max(0, Math.floor((remaining * deltaMillis) / deltaProcessed));
-};
-
 export const formatElapsed = (task: TaskSnapshot, now: number): string => {
   const elapsedMillis = Math.max(0, (task.completedAt ?? now) - task.startedAt);
   return formatDurationSeconds(elapsedMillis / 1000);
@@ -76,17 +40,7 @@ const formatElapsedClock = (task: TaskSnapshot, now: number): string => {
 export const formatEta = (task: TaskSnapshot): string => formatEtaClock(task) ?? "";
 
 const formatEtaClock = (task: TaskSnapshot): string | undefined => {
-  if (task.status !== "running" || !isDeterminate(task)) {
-    return undefined;
-  }
-
-  const { processed, total } = task.units;
-  const remaining = total - processed;
-  if (processed <= 0 || remaining <= 0) {
-    return undefined;
-  }
-
-  const etaMillis = getSmoothedEtaMillis(task);
+  const etaMillis = estimateRemainingMillis(task);
   if (etaMillis === undefined) {
     return undefined;
   }

--- a/src/services/store/store.ts
+++ b/src/services/store/store.ts
@@ -1,3 +1,4 @@
+import { appendProgressSample } from "../../progress-estimation";
 import { Clock, Context, Effect, Layer, Option, Queue } from "effect";
 import type { Column } from "../../columns/types";
 import type { TaskId } from "../../task-model";
@@ -5,7 +6,6 @@ import type { TaskStore } from "./types";
 import type { TaskOperations } from "../task-operations";
 import { TaskId as makeTaskId, type TaskSnapshot } from "../../task-model";
 import {
-  appendProgressSample,
   createTaskSnapshot,
   finalizeTaskSnapshot,
   normalizeUnits,

--- a/src/services/store/task-state.ts
+++ b/src/services/store/task-state.ts
@@ -1,14 +1,11 @@
 import type { AddTaskOptions, UpdateTaskOptions } from "../../tasks/options";
-import type { TaskId, TaskProgressSample, TaskSnapshot } from "../../task-model";
+import type { TaskId, TaskSnapshot } from "../../task-model";
 
 interface TaskCounts {
   readonly succeeded: number;
   readonly failed: number;
   readonly total?: number;
 }
-
-const ETA_SAMPLE_WINDOW_MILLIS = 30_000;
-const ETA_SAMPLE_MAX_LENGTH = 1_000;
 
 const hasExplicitTotal = (options: Pick<AddTaskOptions | UpdateTaskOptions, "total">) =>
   Object.prototype.hasOwnProperty.call(options, "total");
@@ -51,38 +48,6 @@ const completedUnits = (units: TaskSnapshot["units"]): TaskSnapshot["units"] => 
         succeeded: units.succeeded + (units.total - units.processed),
       })
     : units;
-};
-
-/**
- * Returns a new progress sample deque with the latest processed count appended.
- *
- * Samples are retained for the ETA rolling window and capped by count so very chatty tasks do not
- * grow memory without bound.
- */
-export const appendProgressSample = (
-  samples: ReadonlyArray<TaskProgressSample> | undefined,
-  now: number,
-  processed: number,
-): ReadonlyArray<TaskProgressSample> => {
-  const previousSamples = samples ?? [];
-  const lastSample = previousSamples.at(-1);
-  if (lastSample?.processed === processed) {
-    return previousSamples;
-  }
-
-  // Keep one sample immediately before the rolling window when possible. That gives the ETA
-  // calculation a usable delta even just after old samples age out of the 30s window.
-  const windowStart = now - ETA_SAMPLE_WINDOW_MILLIS;
-  const appendedLength = previousSamples.length + 1;
-  let firstRetainedIndex = Math.max(0, appendedLength - ETA_SAMPLE_MAX_LENGTH);
-  while (
-    firstRetainedIndex + 1 < previousSamples.length &&
-    previousSamples[firstRetainedIndex + 1]!.timestamp < windowStart
-  ) {
-    firstRetainedIndex++;
-  }
-
-  return [...previousSamples.slice(firstRetainedIndex), { timestamp: now, processed }];
 };
 
 /** Applies mutable task fields; the mutation boundary records progress samples. */


### PR DESCRIPTION
## Problem

ETA depends on two pieces of one algorithm that live in unrelated places: task-state code retains the sample window, while renderer formatting computes recent throughput. Changing retention requires knowing how the formatter interprets the first and last retained samples. The formatter also duplicates checks for whether any work remains.

## Solution

Put sample retention and remaining-time estimation in `src/progress-estimation.ts`:

- `appendProgressSample` keeps the existing 30-second rolling window, one observation just before that window when available, and the 1,000-sample cap.
- `estimateRemainingMillis` owns eligibility checks and throughput calculation, returning a duration or `undefined`.
- The store still appends observations at the atomic mutation boundary.
- Renderer formatting consumes the estimate and only turns it into display text; the redundant remaining-work check is removed.

The estimator accepts a task snapshot directly. It returns no estimate for completed/failed tasks, unknown totals, no remaining work, or insufficient positive time/progress deltas. These are the same conditions previously enforced by the formatter and its helper together.

## Examples

### Recent throughput

For a running task with 12 total units and 11 processed, retained observations at `(10,000ms, 1)` and `(40,000ms, 11)` represent 10 units over 30 seconds. The remaining unit is estimated at 3,000ms, which the ETA column formats as `ETA: 00:03`.

### A quiet task crossing the window

Retaining one sample immediately before the rolling window still allows a useful delta when old samples age out. The retention comment and the code that interprets those endpoints now live in the same module.

### No available estimate

A task with only its initial observation has no measured throughput. `estimateRemainingMillis` returns `undefined`; the standalone ETA remains empty and the combined elapsed/ETA display retains its existing fallback. Unknown totals and terminal task states retain their current output behavior.

## Validation

- `bun test`: 130 passed, 0 failed, 396 assertions.
- `bun run check`: typecheck, lint, formatting, and Knip passed.
- `bun run format` applied; staged diff whitespace check passed.

Existing store tests cover unchanged processed counts, the sample cap, and retention across the rolling window. Existing rendered ETA tests cover estimates, completed tasks, long durations, and sample-based throughput. Non-failing TSGO schema suggestions remain. No build or dev server was run.

## Review notes

This layer follows the type/API refactors. Review the two functions in `progress-estimation.ts`, then the store import and the smaller formatter. No timing constants, sampling cadence, public schemas, or public exports change, and the new module has no renderer dependency.

## Stack

GitHub stack #63: `main` → #58 (types) → #59 (execution) → #60 (ETA) → #61 (tests) → #62 (examples). Each PR is based on the layer below it, so its diff contains only that concern. Manage the chain with `gh stack`; no PR has been merged by this change.
