### PR TITLE
test: organize coverage by behavior and feature

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -37,8 +37,8 @@ creating a fresh preparation function inside each factory would split shared gro
 Keep clock subscriptions in the cells that need them; the store publish interval,
 spinner clock, elapsed-time clock, and Ink frame limit serve different purposes.
 
-Relevant tests are `tests/prepare-rows.test.ts` for row reuse,
-`tests/prepare-columns.test.ts` for preparation identity and binding,
-`tests/column-layout.test.tsx` for mixed columns and sizing, and
-`tests/renderer-clock-hooks.test.tsx` for selective clock updates. The renderer and
+Relevant tests are `tests/renderer/prepare-rows.test.ts` for row reuse,
+`tests/renderer/prepare-columns.test.ts` for preparation identity and binding,
+`tests/renderer/column-layout.test.tsx` for mixed columns and sizing, and
+`tests/renderer/clock-hooks.test.tsx` for selective clock updates. The renderer and
 column tests also exercise nested output, narrow widths, amounts, bars, and ETA.

--- a/tests/api/execution.test.ts
+++ b/tests/api/execution.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { Console, Effect, Exit, Logger, Option, Result } from "effect";
 import { pipe } from "effect/Function";
-import * as Progress from "../src";
-import { Renderer } from "../src/renderer/renderer";
-import { createMockStdio } from "./helpers/mock-stdio";
+import * as Progress from "../../src";
+import { Renderer } from "../../src/renderer/renderer";
+import { createMockStdio } from "../helpers/mock-stdio";
 
 const withLogSpy = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   Effect.gen(function* () {

--- a/tests/api/infer-total.test.ts
+++ b/tests/api/infer-total.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { inferTotal } from "../src/api/infer-total";
+import { inferTotal } from "../../src/api/infer-total";
 
 describe("inferTotal", () => {
   test.each([

--- a/tests/api/types.test.ts
+++ b/tests/api/types.test.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf, test } from "bun:test";
 import { Context, Effect, Result } from "effect";
-import * as Progress from "../src";
+import * as Progress from "../../src";
 
 class Dependency extends Context.Service<Dependency, { readonly value: number }>()(
   "test/Dependency",

--- a/tests/columns/description.test.tsx
+++ b/tests/columns/description.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import * as Progress from "../src";
-import { makeTaskSnapshot, makeRows, renderRows } from "./helpers/renderer";
-import type { TaskRowModel } from "../src/renderer/row-model";
+import * as Progress from "../../src";
+import { makeTaskSnapshot, makeRows, renderRows } from "../helpers/renderer";
+import type { TaskRowModel } from "../../src/renderer/row-model";
 
 const makeTask = (
   id: number,

--- a/tests/columns/eta.test.tsx
+++ b/tests/columns/eta.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import * as Progress from "../src";
-import { makeTaskSnapshot, makeRow as deriveRow, renderRows } from "./helpers/renderer";
+import * as Progress from "../../src";
+import { makeTaskSnapshot, makeRow as deriveRow, renderRows } from "../helpers/renderer";
 
 const makeTask = (overrides: Partial<Progress.TaskSnapshot> = {}): Progress.TaskSnapshot =>
   makeTaskSnapshot({ description: "eta-task", ...overrides });

--- a/tests/columns/progress.test.tsx
+++ b/tests/columns/progress.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import * as Progress from "../src";
-import { makeTaskSnapshot, makeRow as deriveRow, renderRows } from "./helpers/renderer";
+import * as Progress from "../../src";
+import { makeTaskSnapshot, makeRow as deriveRow, renderRows } from "../helpers/renderer";
 
 const makeTask = (
   id: number,

--- a/tests/renderer/clock-hooks.test.tsx
+++ b/tests/renderer/clock-hooks.test.tsx
@@ -1,12 +1,12 @@
 import { expect, onTestFinished, test } from "bun:test";
 import { render, Text } from "ink";
 import stripAnsi from "strip-ansi";
-import { useNow, useSpinnerTick, type Column } from "../src";
-import { NowProvider } from "../src/renderer/context/now-context";
-import { SpinnerProvider } from "../src/renderer/context/spinner-context";
-import { ProgressTable } from "../src/renderer/progress-table";
-import { createMockStdio } from "./helpers/mock-stdio";
-import { makeRows, makeTaskSnapshot } from "./helpers/renderer";
+import { useNow, useSpinnerTick, type Column } from "../../src";
+import { NowProvider } from "../../src/renderer/context/now-context";
+import { SpinnerProvider } from "../../src/renderer/context/spinner-context";
+import { ProgressTable } from "../../src/renderer/progress-table";
+import { createMockStdio } from "../helpers/mock-stdio";
+import { makeRows, makeTaskSnapshot } from "../helpers/renderer";
 
 test("clock hooks update only subscribed cells and can unsubscribe and resume", async () => {
   const calls = { column: 0, spinner: 0, now: 0 };

--- a/tests/renderer/column-layout.test.tsx
+++ b/tests/renderer/column-layout.test.tsx
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import * as Progress from "../src";
-import { makeTaskSnapshot, makeRow as deriveRow, renderRows } from "./helpers/renderer";
-import { resolveColumns } from "../src/renderer/column-layout";
-import type { TaskRowModel } from "../src/renderer/row-model";
+import * as Progress from "../../src";
+import { makeTaskSnapshot, makeRow as deriveRow, renderRows } from "../helpers/renderer";
+import { resolveColumns } from "../../src/renderer/column-layout";
+import type { TaskRowModel } from "../../src/renderer/row-model";
 
 const makeTask = <M,>(
   id: number,

--- a/tests/renderer/format.test.ts
+++ b/tests/renderer/format.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import * as Progress from "../src";
-import { getTaskIndicator } from "../src/columns/description";
-import { formatAmount } from "../src/renderer/shared/format";
+import * as Progress from "../../src";
+import { getTaskIndicator } from "../../src/columns/description";
+import { formatAmount } from "../../src/renderer/shared/format";
 
 const makeTask = (
   units: Progress.TaskSnapshot["units"],

--- a/tests/renderer/integration.test.ts
+++ b/tests/renderer/integration.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { Console, Effect } from "effect";
 import stripAnsi from "strip-ansi";
-import * as Progress from "../src";
-import { createMockStdio } from "./helpers/mock-stdio";
+import * as Progress from "../../src";
+import { createMockStdio } from "../helpers/mock-stdio";
 
 const captureStdioOutput = async <A, E>(
   effect: Effect.Effect<A, E, Progress.ProgressStdio>,

--- a/tests/renderer/lifecycle.test.ts
+++ b/tests/renderer/lifecycle.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { Effect, Exit } from "effect";
-import { Progress } from "../src/services/progress";
-import { Renderer } from "../src/renderer/renderer";
+import { Progress } from "../../src/services/progress";
+import { Renderer } from "../../src/renderer/renderer";
 
 test.each([false, true])(
   "renderer starts before work and releases on scope exit (failure: %s)",

--- a/tests/renderer/prepare-columns.test.ts
+++ b/tests/renderer/prepare-columns.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
-import type { CellInfo, ColumnDef } from "../src/columns/types";
-import { TaskId } from "../src/task-model";
-import { resolveColumns } from "../src/renderer/column-layout";
-import { makeRows, makeTaskSnapshot } from "./helpers/renderer";
+import type { CellInfo, ColumnDef } from "../../src/columns/types";
+import { TaskId } from "../../src/task-model";
+import { resolveColumns } from "../../src/renderer/column-layout";
+import { makeRows, makeTaskSnapshot } from "../helpers/renderer";
 
 test("shared preparation runs once per position and stays bound to each renderer and sizing hint", () => {
   const calls: number[] = [];

--- a/tests/renderer/prepare-rows.test.ts
+++ b/tests/renderer/prepare-rows.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { TaskId, type TaskSnapshot } from "../src/task-model";
-import { type TaskStore } from "../src/services/store/types";
-import { prepareRows } from "../src/renderer/prepare-rows";
+import { TaskId, type TaskSnapshot } from "../../src/task-model";
+import { type TaskStore } from "../../src/services/store/types";
+import { prepareRows } from "../../src/renderer/prepare-rows";
 
 const makeTask = (id: number, description: string): TaskSnapshot => ({
   id: TaskId(id),

--- a/tests/renderer/rows.test.tsx
+++ b/tests/renderer/rows.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import * as Progress from "../src";
-import { makeTaskSnapshot, makeRow as deriveRow, renderRows } from "./helpers/renderer";
+import * as Progress from "../../src";
+import { makeTaskSnapshot, makeRow as deriveRow, renderRows } from "../helpers/renderer";
 
 const makeTask = (id: number): Progress.TaskSnapshot =>
   makeTaskSnapshot({

--- a/tests/renderer/spinner-clock.test.ts
+++ b/tests/renderer/spinner-clock.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getSpinnerTickAtTime } from "../src/renderer/hooks/use-spinner-clock";
+import { getSpinnerTickAtTime } from "../../src/renderer/hooks/use-spinner-clock";
 
 describe("spinner clock", () => {
   test("advances frames from elapsed time instead of callback count", () => {

--- a/tests/renderer/stdio.test.ts
+++ b/tests/renderer/stdio.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Effect } from "effect";
-import * as Progress from "../src";
-import { createMockStdio } from "./helpers/mock-stdio";
+import * as Progress from "../../src";
+import { createMockStdio } from "../helpers/mock-stdio";
 
 describe("ProgressStdio", () => {
   test("mock service can override stdout and stderr metadata independently", async () => {

--- a/tests/store/state.test.ts
+++ b/tests/store/state.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { Effect, Option } from "effect";
 import { TestClock } from "effect/testing";
-import type { ColumnDef } from "../src";
-import { makeProgressStore } from "../src/services/store/store";
+import type { ColumnDef } from "../../src";
+import { makeProgressStore } from "../../src/services/store/store";
 
-describe("progress render store", () => {
+describe("progress store state and publication", () => {
   test.each([[NaN], [Infinity], [-Infinity]] as const)(
     "clears non-finite total %s on creation",
     async (total) => {

--- a/tests/tasks/counters-and-policies.test.ts
+++ b/tests/tasks/counters-and-policies.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Effect, Option } from "effect";
-import * as Progress from "../src";
-import { createMockStdio } from "./helpers/mock-stdio";
+import * as Progress from "../../src";
+import { createMockStdio } from "../helpers/mock-stdio";
 
 const withStdio = <A, E, R>(effect: Effect.Effect<A, E, R>) => {
   const stdio = createMockStdio();

--- a/tests/tasks/finalization.test.ts
+++ b/tests/tasks/finalization.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Deferred, Effect, Exit, Fiber } from "effect";
-import * as Progress from "../src";
-import { Renderer } from "../src/renderer/renderer";
+import * as Progress from "../../src";
+import { Renderer } from "../../src/renderer/renderer";
 
 const withProgress = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   effect.pipe(

--- a/tests/tasks/model.test.ts
+++ b/tests/tasks/model.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Schema } from "effect";
-import * as Progress from "../src";
+import * as Progress from "../../src";
 
 describe("types and schemas", () => {
   test("TaskSnapshot validates with progress samples", () => {


### PR DESCRIPTION
## Problem

The flat test directory makes it difficult to find the behavior a maintainer needs to understand. Names such as `runtime.test.ts`, `types.test.ts`, and `ink-renderer-store.test.ts` hide whether a file exercises task policy, public execution, store publication, or rendered output. The source now has clearer owners, but the tests do not reflect them.

## Solution

Group the existing suites by behavior and update their imports:

- `tests/api/`: public execution, overload inference, and iterable total inference.
- `tests/tasks/`: counters and inherited policies, finalization, and the task data model.
- `tests/store/`: state mutation and snapshot publication.
- `tests/renderer/`: preparation, layout, clocks, formatting, stdio, lifecycle, and integrated output.
- `tests/columns/`: description, ETA, and progress column output.

Keep shared fixtures in `tests/helpers/`. Rename the store describe block to identify state and publication. Update only the existing test paths in `DEVELOPMENT.md`; no new development-guide section is added.

## Examples

### Investigating counter overflow

Before: infer that `runtime.test.ts` might contain the relevant behavior.

After: open `tests/tasks/counters-and-policies.test.ts`, which retains the examples for overflow, completion, invalid totals, transient inheritance, and count-display policy.

### Investigating delayed terminal updates

Start with `tests/store/state.test.ts` for publication coalescing, immediate task reads, flush, and subscriptions. Then use `tests/renderer/lifecycle.test.ts` for final output at shutdown. The directory structure makes the boundary between state publication and rendering visible.

### Running one area

```bash
bun test tests/columns
bun test tests/api
```

The full command remains `bun test`, and the existing recursive typecheck/Knip configuration still discovers every file.

## Validation

- `bun test`: 130 passed across 20 files, 0 failed, 396 assertions—the same counts as before the moves.
- `bun run check`: typecheck, lint, formatting, and Knip passed.
- `bun run format` applied; staged diff whitespace check passed.

Test bodies, assertions, fixtures, and behavioral coverage are preserved. Non-failing TSGO schema suggestions remain. No new tests, production changes, builds, or dev servers were introduced in this layer.

## Review notes

This layer follows the code-ownership refactors. Review with rename detection: the changes are file locations, relative imports, one describe label, and four existing documentation paths. It does not split or duplicate suites merely to increase file count.

## Stack

GitHub stack #63: `main` → #58 (types) → #59 (execution) → #60 (ETA) → #61 (tests) → #62 (examples). Each PR is based on the layer below it, so its diff contains only that concern. Manage the chain with `gh stack`; no PR has been merged by this change.
