### PR TITLE
refactor!: make task handles the public metadata API

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,6 @@ The handle exposes:
 - `complete`
 - `fail`
 
-Metadata is read and updated through the typed callback handle. The Progress service
-does not expose metadata getters or setters by task ID. When migrating from
-`progress.setMetadata(id, value)`, keep the handle supplied by `Progress.task` and
-call `handle.setMetadata(value)` instead.
-
 When you need lower-level control, the `Progress` service is available inside the effect and exposes APIs like `addTask`, `updateTask`, `incrementSucceeded(taskId, amount)`, and `completeTask(taskId)`.
 
 The primary v4-style service layers are exposed as `Progress.layer` and `ProgressStdio.layer`.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ The handle exposes:
 - `complete`
 - `fail`
 
+Metadata is read and updated through the typed callback handle. The Progress service
+does not expose metadata getters or setters by task ID. When migrating from
+`progress.setMetadata(id, value)`, keep the handle supplied by `Progress.task` and
+call `handle.setMetadata(value)` instead.
+
 When you need lower-level control, the `Progress` service is available inside the effect and exposes APIs like `addTask`, `updateTask`, `incrementSucceeded(taskId, amount)`, and `completeTask(taskId)`.
 
 The primary v4-style service layers are exposed as `Progress.layer` and `ProgressStdio.layer`.

--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -101,8 +101,6 @@ const makeProgressService = Effect.gen(function* () {
     failTask: store.failTask,
     getTask: store.getTask,
     listTasks: store.listTasks,
-    setMetadata: store.setMetadata,
-    getMetadata: store.getMetadata,
     task,
   } satisfies ProgressService;
 

--- a/src/services/store/store.ts
+++ b/src/services/store/store.ts
@@ -19,6 +19,9 @@ export interface ProgressStoreService extends TaskOperations {
   readonly getPublishedSnapshot: () => TaskStore;
   readonly subscribe: (listener: () => void) => () => void;
   readonly flush: () => void;
+  /** Internal metadata operations are exposed publicly only through a typed task handle. */
+  readonly setMetadata: <M>(taskId: TaskId, metadata: M) => Effect.Effect<void>;
+  readonly getMetadata: (taskId: TaskId) => Effect.Effect<unknown>;
   readonly updateMetadata: (
     taskId: TaskId,
     f: (metadata: TaskSnapshot["metadata"]) => TaskSnapshot["metadata"],

--- a/src/services/task-operations.ts
+++ b/src/services/task-operations.ts
@@ -12,6 +12,4 @@ export interface TaskOperations {
   readonly failTask: (taskId: TaskId) => Effect.Effect<void>;
   readonly getTask: (taskId: TaskId) => Effect.Effect<Option.Option<TaskSnapshot>>;
   readonly listTasks: Effect.Effect<ReadonlyArray<TaskSnapshot>>;
-  readonly setMetadata: <M>(taskId: TaskId, metadata: M) => Effect.Effect<void>;
-  readonly getMetadata: (taskId: TaskId) => Effect.Effect<unknown>;
 }

--- a/tests/api/types.test.ts
+++ b/tests/api/types.test.ts
@@ -19,6 +19,8 @@ test("task overloads preserve values, errors, metadata and unrelated requirement
     Progress.task(
       (handle) => {
         expectTypeOf(handle.getMetadata).toEqualTypeOf<Effect.Effect<{ score: number }>>();
+        // @ts-expect-error Metadata writes must retain the type inferred at task creation.
+        const invalidWrite = handle.setMetadata({ score: "wrong type" });
         return Effect.fail("failure" as const);
       },
       { description: "metadata", metadata: { score: 0 } },

--- a/tests/api/types.test.ts
+++ b/tests/api/types.test.ts
@@ -20,7 +20,7 @@ test("task overloads preserve values, errors, metadata and unrelated requirement
       (handle) => {
         expectTypeOf(handle.getMetadata).toEqualTypeOf<Effect.Effect<{ score: number }>>();
         // @ts-expect-error Metadata writes must retain the type inferred at task creation.
-        const invalidWrite = handle.setMetadata({ score: "wrong type" });
+        const _invalidWrite = handle.setMetadata({ score: "wrong type" });
         return Effect.fail("failure" as const);
       },
       { description: "metadata", metadata: { score: 0 } },


### PR DESCRIPTION
## Problem

Task handles promise metadata of the type inferred at creation, but the public Progress service also accepts unrestricted metadata writes by task ID. A caller could create `TaskHandle<number>`, call `progress.setMetadata(handle.id, "text")`, and then read a string from an effect typed as returning a number. The service-level getter also loses the handle's metadata type.

## Solution

Make the typed task handle the public metadata API, as requested:

- Remove `setMetadata(taskId, value)` and `getMetadata(taskId)` from the public shared operations and Progress service implementation.
- Retain `handle.getMetadata`, `handle.setMetadata`, and `handle.updateMetadata` with their creation-time metadata type.
- Keep backing-store metadata operations internal for handle implementation.
- Add a negative type assertion to the existing overload test so a wrong-type handle write fails type checking.

Task creation can still supply metadata, and snapshots/custom columns still expose metadata through their existing contracts. The raw task-ID lifecycle and counter APIs remain available.

## Examples

Before, this public service call could violate a handle's type:

```ts
// handle was created with numeric metadata
// Previously accepted by the Progress service:
yield* progress.setMetadata(handle.id, "wrong type");
```

Typed handle usage:

```ts
Progress.task(
  (handle) => handle.updateMetadata((score) => score + 1),
  { description: "score", metadata: 0 },
);
```

`handle.setMetadata("wrong type")` is now rejected for this handle, and the public service no longer offers the ID-based escape hatch. Metadata reads and snapshot reads become optional in the next stack layer, rather than changing that separate contract here.

## Validation

- `bun test`: 130 passed, 0 failed, 396 assertions.
- `bun run check`: typecheck, lint, formatting, and Knip passed.
- `bun run format` applied; staged diff whitespace check passed.

The existing concurrent metadata-update test still verifies that all increments survive. The type suite verifies metadata inference and rejects incompatible setter input. Existing non-failing TSGO suggestions remain in schema definitions/tests. No build or dev server was run.

## Review notes

Review the public operations interface and service projection first. The internal store remains an implementation detail; this does not freeze or clone user-owned metadata objects.

## Stack

GitHub stack #67: `main` → #64 (handle metadata API) → #65 (optional reads) → #66 (state invariants). Each PR is based on the layer below it. Manage the chain with `gh stack`.
