### PR TITLE
fix!: return optional task handle reads after removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,19 @@ The handle exposes:
 - `complete`
 - `fail`
 
+Handle reads return `Effect<Option<...>>`: `getMetadata` yields `Option<M>` and
+`getSnapshot` yields `Option<TaskSnapshot>`. Removing a transient task (or its parent)
+makes both reads return `None`. A retained task with `undefined` metadata returns
+`Some(undefined)`. Handle writes to removed tasks are no-ops, and `updateMetadata`
+does not invoke its callback for a removed task.
+
+```ts
+const metadata = yield * handle.getMetadata;
+if (Option.isSome(metadata)) {
+  // metadata.value has the metadata type inferred when the task was created.
+}
+```
+
 When you need lower-level control, the `Progress` service is available inside the effect and exposes APIs like `addTask`, `updateTask`, `incrementSucceeded(taskId, amount)`, and `completeTask(taskId)`.
 
 The primary v4-style service layers are exposed as `Progress.layer` and `ProgressStdio.layer`.

--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -56,8 +56,14 @@ const makeProgressService = Effect.gen(function* () {
 
   const makeTaskHandle = <M>(taskId: TaskId): TaskHandle<M> => ({
     id: taskId,
-    // SAFETY: This handle belongs to the task created with metadata M; handle writes preserve M.
-    getMetadata: store.getMetadata(taskId) as Effect.Effect<M>,
+    getMetadata: store.getTask(taskId).pipe(
+      Effect.map(
+        Option.map((task) => {
+          // SAFETY: This task was created with M; only its typed handle exposes metadata writes.
+          return task.metadata as M;
+        }),
+      ),
+    ),
     setMetadata: (metadata) => store.setMetadata(taskId, metadata),
     updateMetadata: (f) =>
       store.updateMetadata(taskId, (current) =>
@@ -69,7 +75,7 @@ const makeProgressService = Effect.gen(function* () {
     update: (options) => store.updateTask(taskId, options),
     complete: store.completeTask(taskId),
     fail: store.failTask(taskId),
-    getSnapshot: store.getTask(taskId).pipe(Effect.map(Option.getOrThrow)),
+    getSnapshot: store.getTask(taskId),
   });
 
   const task = adaptTaskApi<Task>(

--- a/src/services/store/store.ts
+++ b/src/services/store/store.ts
@@ -21,7 +21,6 @@ export interface ProgressStoreService extends TaskOperations {
   readonly flush: () => void;
   /** Internal metadata operations are exposed publicly only through a typed task handle. */
   readonly setMetadata: <M>(taskId: TaskId, metadata: M) => Effect.Effect<void>;
-  readonly getMetadata: (taskId: TaskId) => Effect.Effect<unknown>;
   readonly updateMetadata: (
     taskId: TaskId,
     f: (metadata: TaskSnapshot["metadata"]) => TaskSnapshot["metadata"],
@@ -134,11 +133,6 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
     setMetadata: (taskId, metadata) => modifyTask(taskId, (task) => ({ ...task, metadata })),
     updateMetadata: (taskId, f) =>
       modifyTask(taskId, (task) => ({ ...task, metadata: f(task.metadata) })),
-    getMetadata: (taskId) =>
-      Effect.sync(() => {
-        const task = state.tasks.get(taskId);
-        return task?.metadata;
-      }),
   };
 
   return { store, publisherLoop: publisher.publisherLoop };

--- a/src/tasks/task-handle.ts
+++ b/src/tasks/task-handle.ts
@@ -1,4 +1,4 @@
-import type { Effect } from "effect";
+import type { Effect, Option } from "effect";
 import type { TaskId, TaskSnapshot } from "../task-model";
 import type { UpdateTaskOptions } from "./options";
 
@@ -11,8 +11,8 @@ import type { UpdateTaskOptions } from "./options";
  */
 export interface TaskHandle<M> {
   readonly id: TaskId;
-  /** Reads the current metadata value for the task using the metadata type inferred at creation. */
-  readonly getMetadata: Effect.Effect<M>;
+  /** Reads typed metadata; None means the task was removed. Present undefined metadata is Some(undefined). */
+  readonly getMetadata: Effect.Effect<Option.Option<M>>;
   /** Replaces the task metadata. */
   readonly setMetadata: (metadata: M) => Effect.Effect<void>;
   /** Updates the current metadata value atomically. */
@@ -27,6 +27,6 @@ export interface TaskHandle<M> {
   readonly complete: Effect.Effect<void>;
   /** Marks the task as failed immediately. Finalization is terminal once the task leaves `running`. */
   readonly fail: Effect.Effect<void>;
-  /** Reads the latest task snapshot. */
-  readonly getSnapshot: Effect.Effect<TaskSnapshot>;
+  /** Reads the latest snapshot, or None if the task was removed. */
+  readonly getSnapshot: Effect.Effect<Option.Option<TaskSnapshot>>;
 }

--- a/tests/api/types.test.ts
+++ b/tests/api/types.test.ts
@@ -1,5 +1,5 @@
 import { expectTypeOf, test } from "bun:test";
-import { Context, Effect, Result } from "effect";
+import { Context, Effect, Option, Result } from "effect";
 import * as Progress from "../../src";
 
 class Dependency extends Context.Service<Dependency, { readonly value: number }>()(
@@ -18,7 +18,12 @@ test("task overloads preserve values, errors, metadata and unrelated requirement
   expectTypeOf(
     Progress.task(
       (handle) => {
-        expectTypeOf(handle.getMetadata).toEqualTypeOf<Effect.Effect<{ score: number }>>();
+        expectTypeOf(handle.getMetadata).toEqualTypeOf<
+          Effect.Effect<Option.Option<{ score: number }>>
+        >();
+        expectTypeOf(handle.getSnapshot).toEqualTypeOf<
+          Effect.Effect<Option.Option<Progress.TaskSnapshot>>
+        >();
         // @ts-expect-error Metadata writes must retain the type inferred at task creation.
         const _invalidWrite = handle.setMetadata({ score: "wrong type" });
         return Effect.fail("failure" as const);

--- a/tests/tasks/finalization.test.ts
+++ b/tests/tasks/finalization.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { Deferred, Effect, Exit, Fiber } from "effect";
+import { Deferred, Effect, Exit, Fiber, Option } from "effect";
 import * as Progress from "../../src";
 import { Renderer } from "../../src/renderer/renderer";
 
@@ -28,9 +28,9 @@ describe("task exit finalization", () => {
         ),
       ),
     );
-    expect(result.metadata).toBe(200);
-    expect(result.snapshot.units.processed).toBe(0);
-    expect(result.snapshot.progressSamples).toHaveLength(1);
+    expect(result.metadata).toEqual(Option.some(200));
+    expect(Option.getOrThrow(result.snapshot).units.processed).toBe(0);
+    expect(Option.getOrThrow(result.snapshot).progressSamples).toHaveLength(1);
   });
 
   test("finalizes a callback that throws before returning an Effect", async () => {

--- a/tests/tasks/handle-reads.test.ts
+++ b/tests/tasks/handle-reads.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "bun:test";
+import { Effect, Option } from "effect";
+import * as Progress from "../../src";
+import { Renderer } from "../../src/renderer/renderer";
+
+const withProgress = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  effect.pipe(
+    Effect.provide(Progress.Progress.layer),
+    Effect.provideService(Renderer, { start: Effect.void }),
+    Effect.scoped,
+  );
+
+test.each([undefined, null, 0])("preserves present metadata %s in Some", async (metadata) => {
+  const result = await Effect.runPromise(
+    withProgress(
+      Progress.task(
+        (handle) =>
+          Effect.gen(function* () {
+            return { metadata: yield* handle.getMetadata, snapshot: yield* handle.getSnapshot };
+          }),
+        { description: "present", metadata },
+      ),
+    ),
+  );
+  expect(result.metadata).toEqual(Option.some(metadata));
+  expect(Option.isSome(result.snapshot)).toBeTrue();
+});
+
+test.each(["complete", "fail"] as const)("returns None after transient %s", async (finalize) => {
+  const result = await Effect.runPromise(
+    withProgress(
+      Progress.task(
+        (handle) =>
+          Effect.gen(function* () {
+            yield* handle.setMetadata(2);
+            expect(yield* handle.getMetadata).toEqual(Option.some(2));
+            yield* handle[finalize];
+            yield* handle.setMetadata(3);
+            let updaterCalled = false;
+            yield* handle.updateMetadata((value) => {
+              updaterCalled = true;
+              return value + 1;
+            });
+            return {
+              metadata: yield* handle.getMetadata,
+              snapshot: yield* handle.getSnapshot,
+              updaterCalled,
+            };
+          }),
+        { description: "transient", metadata: 1, transient: true },
+      ),
+    ),
+  );
+  expect(result).toEqual({
+    metadata: Option.none(),
+    snapshot: Option.none(),
+    updaterCalled: false,
+  });
+});
+
+test("child reads return None after a transient parent removes the subtree", async () => {
+  const result = await Effect.runPromise(
+    withProgress(
+      Progress.task(
+        (parent) =>
+          Progress.task(
+            (child) =>
+              Effect.gen(function* () {
+                yield* parent.complete;
+                return { metadata: yield* child.getMetadata, snapshot: yield* child.getSnapshot };
+              }),
+            { description: "child", metadata: "child metadata" },
+          ),
+        { description: "parent", transient: true },
+      ),
+    ),
+  );
+  expect(result).toEqual({ metadata: Option.none(), snapshot: Option.none() });
+});
+
+test("retained tasks remain readable after completion", async () => {
+  const result = await Effect.runPromise(
+    withProgress(
+      Progress.task(
+        (handle) =>
+          Effect.gen(function* () {
+            yield* handle.complete;
+            return { metadata: yield* handle.getMetadata, snapshot: yield* handle.getSnapshot };
+          }),
+        { description: "retained", metadata: 42 },
+      ),
+    ),
+  );
+  expect(result.metadata).toEqual(Option.some(42));
+  expect(Option.getOrThrow(result.snapshot).status).toBe("done");
+});


### PR DESCRIPTION
## Problem

Completing a transient task removes it immediately, but its handle still claims its metadata and snapshot always exist. After removal, `getMetadata` returned `undefined` despite its `M` return type, and `getSnapshot` defected through `Option.getOrThrow`. Removing a transient parent causes the same problem for child handles.

## Solution

Return an Option from both handle reads, as requested:

- `handle.getMetadata`: `Effect<Option<M>>`.
- `handle.getSnapshot`: `Effect<Option<TaskSnapshot>>`.

Derive metadata from the optional stored task, so absence is determined by task existence instead of the metadata value. An existing task containing `undefined` or `null` metadata therefore returns `Some(undefined)` or `Some(null)`; a removed task returns `None`.

Remove the obsolete internal metadata getter. Update existing type/finalization assertions and document optional reads and removed-task write behavior. Retained completed tasks remain readable; writes to removed tasks stay no-ops, and metadata update callbacks are not invoked for them.

## Examples

Reading metadata:

```ts
const metadata = yield* handle.getMetadata;
if (Option.isSome(metadata)) {
  // Use metadata.value with the metadata type inferred at creation.
}
```

For a task created with `{ metadata: 42, transient: true }`, reads initially return `Some(42)` and `Some(snapshot)`. After `yield* handle.complete`, both return `None` without defecting. `handle.fail` has the same removal behavior. Removing a transient parent also makes its child handles return `None`.

For a retained task created with `metadata: undefined`, the metadata read is `Some(undefined)` both while running and after completion. That is distinct from a missing task.

## Validation

- `bun test`: 137 passed, 0 failed, 409 assertions.
- `bun run check`: typecheck, lint, formatting, and Knip passed.
- `bun run format` applied; staged diff whitespace check passed.

New behavioral tests cover present undefined/null/zero metadata, removal through completion and failure, stale-handle writes and updater suppression, parent subtree removal, and reads after retained completion. Type checks cover both optional return types. Existing non-failing TSGO schema suggestions remain. No build or dev server was run.

## Review notes

The raw service `getTask` already returns an Option and is unchanged. This layer follows the removal of service-level metadata access. Start with the handle interface and the service's Option mapping, then the lifecycle cases in `tests/tasks/handle-reads.test.ts`.

## Stack

GitHub stack #67: `main` → #64 (handle metadata API) → #65 (optional reads) → #66 (state invariants). Each PR is based on the layer below it. Manage the chain with `gh stack`.
