### PR TITLE
fix!: enforce task counter, finalization, and parent invariants

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,9 @@ if (Option.isSome(metadata)) {
 
 Task mutation rules:
 
-- Completion and failure freeze the retained task's fields, counters, timestamps,
-  progress samples, and metadata. Later writes are no-ops, and metadata update
-  callbacks are not invoked. Retained tasks remain readable through `Some`.
+- Completion and failure make later task API writes no-ops, including counter,
+  field, and metadata updates. Metadata update callbacks are not invoked. Retained
+  tasks remain readable through `Some`; metadata objects are not deep-frozen.
 - Counter values stay finite and nonnegative. Non-finite counter inputs preserve
   the previous value; if the resulting succeeded-plus-failed sum would overflow to
   infinity, both counter changes are ignored. Finite counts may still exceed the

--- a/README.md
+++ b/README.md
@@ -197,6 +197,19 @@ if (Option.isSome(metadata)) {
 }
 ```
 
+Task mutation rules:
+
+- Completion and failure freeze the retained task's fields, counters, timestamps,
+  progress samples, and metadata. Later writes are no-ops, and metadata update
+  callbacks are not invoked. Retained tasks remain readable through `Some`.
+- Counter values stay finite and nonnegative. Non-finite counter inputs preserve
+  the previous value; if the resulting succeeded-plus-failed sum would overflow to
+  infinity, both counter changes are ignored. Finite counts may still exceed the
+  total, and negative finite values are clamped to zero.
+- Totals retain their existing rules: negative or non-finite totals become unknown.
+- A missing or removed parent ID creates a root task with `parentId: null`, without
+  inheriting policies from the absent parent.
+
 When you need lower-level control, the `Progress` service is available inside the effect and exposes APIs like `addTask`, `updateTask`, `incrementSucceeded(taskId, amount)`, and `completeTask(taskId)`.
 
 The primary v4-style service layers are exposed as `Progress.layer` and `ProgressStdio.layer`.

--- a/src/services/store/store.ts
+++ b/src/services/store/store.ts
@@ -54,7 +54,7 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
     return publisher.publish(state, now);
   };
 
-  /** Replaces a task and records progress in one synchronous state transition. Undefined removes its subtree. */
+  /** Mutates running tasks only, recording progress atomically. Undefined removes the task subtree. */
   const modifyTask = (
     taskId: TaskId,
     transform: (task: TaskSnapshot, now: number) => TaskSnapshot | undefined,
@@ -63,7 +63,7 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
       const now = yield* Clock.currentTimeMillis;
       yield* updateState((current) => {
         const task = current.tasks.get(taskId);
-        if (!task) {
+        if (!task || task.status !== "running") {
           return current;
         }
         const nextTask = transform(task, now);
@@ -89,7 +89,7 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
   const incrementCounter = (taskId: TaskId, kind: "succeeded" | "failed", amount: number) =>
     modifyTask(taskId, (task) => ({
       ...task,
-      units: normalizeUnits({ ...task.units, [kind]: task.units[kind] + amount }),
+      units: normalizeUnits({ ...task.units, [kind]: task.units[kind] + amount }, task.units),
     }));
 
   const finalizeTask = (taskId: TaskId, status: "done" | "failed") =>
@@ -102,12 +102,12 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
     addTask: (options) =>
       Effect.gen(function* () {
         const taskId = makeTaskId(++nextTaskId);
-        const parentSnapshot =
-          options.parentId === undefined ? undefined : state.tasks.get(options.parentId);
         const now = yield* Clock.currentTimeMillis;
-        const task = createTaskSnapshot(taskId, options, parentSnapshot, now);
 
         yield* updateState((current) => {
+          const parentSnapshot =
+            options.parentId === undefined ? undefined : current.tasks.get(options.parentId);
+          const task = createTaskSnapshot(taskId, options, parentSnapshot, now);
           const nextTasks = new Map(current.tasks);
           nextTasks.set(taskId, task);
           const { index, depth } = findInsertionIndex(current.renderOrder, task.parentId);

--- a/src/services/store/task-state.ts
+++ b/src/services/store/task-state.ts
@@ -18,9 +18,18 @@ const sanitizeTotal = (total: number | undefined) => {
   return !Number.isFinite(total) || total < 0 ? undefined : total;
 };
 
-export const normalizeUnits = (counts: TaskCounts) => {
-  const succeeded = Math.max(0, counts.succeeded);
-  const failed = Math.max(0, counts.failed);
+/** Invalid counter inputs preserve prior counts; a non-finite sum rejects both counter changes. */
+export const normalizeUnits = (counts: TaskCounts, previous?: TaskCounts) => {
+  let succeeded = Number.isFinite(counts.succeeded)
+    ? Math.max(0, counts.succeeded)
+    : (previous?.succeeded ?? 0);
+  let failed = Number.isFinite(counts.failed)
+    ? Math.max(0, counts.failed)
+    : (previous?.failed ?? 0);
+  if (!Number.isFinite(succeeded + failed)) {
+    succeeded = previous?.succeeded ?? 0;
+    failed = previous?.failed ?? 0;
+  }
 
   return counts.total === undefined
     ? {
@@ -39,14 +48,19 @@ export const normalizeUnits = (counts: TaskCounts) => {
 /** Completes remaining known work, or records the observed total for an unknown-total task. */
 const completedUnits = (units: TaskSnapshot["units"]): TaskSnapshot["units"] => {
   if (units.total === undefined) {
-    return units.processed > 0 ? normalizeUnits({ ...units, total: units.processed }) : units;
+    return units.processed > 0
+      ? normalizeUnits({ ...units, total: units.processed }, units)
+      : units;
   }
 
   return units.processed < units.total
-    ? normalizeUnits({
-        ...units,
-        succeeded: units.succeeded + (units.total - units.processed),
-      })
+    ? normalizeUnits(
+        {
+          ...units,
+          succeeded: units.succeeded + (units.total - units.processed),
+        },
+        units,
+      )
     : units;
 };
 
@@ -59,11 +73,14 @@ export const updatedSnapshot = (snapshot: TaskSnapshot, options: UpdateTaskOptio
     options.total === undefined &&
     !hasExplicitTotal(options)
       ? currentUnits
-      : normalizeUnits({
-          succeeded: options.succeeded ?? currentUnits.succeeded,
-          failed: options.failed ?? currentUnits.failed,
-          total: hasExplicitTotal(options) ? sanitizeTotal(options.total) : currentUnits.total,
-        });
+      : normalizeUnits(
+          {
+            succeeded: options.succeeded ?? currentUnits.succeeded,
+            failed: options.failed ?? currentUnits.failed,
+            total: hasExplicitTotal(options) ? sanitizeTotal(options.total) : currentUnits.total,
+          },
+          currentUnits,
+        );
 
   return {
     ...snapshot,
@@ -85,7 +102,7 @@ export const createTaskSnapshot = <M>(
     failed: 0,
     total: sanitizeTotal(options.total),
   });
-  const parentId = options.parentId ?? null;
+  const parentId = parent?.id ?? null;
   const countDisplay = options.countDisplay ?? parent?.countDisplay ?? "detailed";
   const task = {
     id: taskId,

--- a/src/services/task-operations.ts
+++ b/src/services/task-operations.ts
@@ -2,7 +2,7 @@ import type { Effect, Option } from "effect";
 import type { TaskId, TaskSnapshot } from "../task-model";
 import type { AddTaskOptions, UpdateTaskOptions } from "../tasks/options";
 
-/** Task operations shared by the progress service and its backing store. */
+/** Task operations shared by the service and store. Mutations of finalized or removed tasks are no-ops. */
 export interface TaskOperations {
   readonly addTask: <M>(options: AddTaskOptions<M>) => Effect.Effect<TaskId>;
   readonly updateTask: (taskId: TaskId, options: UpdateTaskOptions) => Effect.Effect<void>;

--- a/src/tasks/options.ts
+++ b/src/tasks/options.ts
@@ -6,12 +6,14 @@ export interface AddTaskOptions<M = void> {
   readonly total?: number;
   /** Cleanup policy is fixed at creation; a transient parent makes its descendants transient. */
   readonly transient?: boolean;
+  /** Missing or removed parent IDs are normalized to root tasks. */
   readonly parentId?: TaskId;
   readonly countDisplay?: TaskCountDisplay;
   readonly metadata?: M;
   readonly columns?: ReadonlyArray<Column<M>>;
 }
 
+/** Updates apply only while running; non-finite counters preserve their previous values. */
 export interface UpdateTaskOptions {
   readonly description?: string;
   readonly succeeded?: number;

--- a/src/tasks/task-handle.ts
+++ b/src/tasks/task-handle.ts
@@ -8,6 +8,7 @@ import type { UpdateTaskOptions } from "./options";
  * Use this handle to update counts, metadata, description, or to explicitly finalize the task
  * before the callback exits. If the callback returns or fails while the task is still `running`,
  * the library auto-finalizes it from the callback exit status instead.
+ * Mutations after completion, failure, or removal are no-ops; metadata updaters are not invoked.
  */
 export interface TaskHandle<M> {
   readonly id: TaskId;
@@ -17,9 +18,9 @@ export interface TaskHandle<M> {
   readonly setMetadata: (metadata: M) => Effect.Effect<void>;
   /** Updates the current metadata value atomically. */
   readonly updateMetadata: (f: (m: M) => M) => Effect.Effect<void>;
-  /** Increments the succeeded counter for the task. */
+  /** Increments succeeded while running. Non-finite inputs or results are ignored. */
   readonly incrementSucceeded: (amount?: number) => Effect.Effect<void>;
-  /** Increments the failed counter for the task. */
+  /** Increments failed while running. Non-finite inputs or results are ignored. */
   readonly incrementFailed: (amount?: number) => Effect.Effect<void>;
   /** Updates mutable task fields such as description, totals, and count display. */
   readonly update: (options: UpdateTaskOptions) => Effect.Effect<void>;

--- a/tests/store/invariants.test.ts
+++ b/tests/store/invariants.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "bun:test";
+import { Effect, Option } from "effect";
+import { TaskId } from "../../src/task-model";
+import { makeProgressStore } from "../../src/services/store/store";
+
+test.each([NaN, Infinity, -Infinity])("ignores non-finite counter input %s", async (value) => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const store = yield* makeProgressStore;
+      const id = yield* store.addTask({ description: "finite counters", total: 10 });
+      yield* store.updateTask(id, { succeeded: 2, failed: 1 });
+      const before = Option.getOrThrow(yield* store.getTask(id));
+
+      yield* store.incrementSucceeded(id, value);
+      yield* store.incrementFailed(id, value);
+      yield* store.updateTask(id, { succeeded: value, failed: value });
+      const unchanged = Option.getOrThrow(yield* store.getTask(id));
+      expect(unchanged.units).toEqual(before.units);
+      expect(unchanged.progressSamples).toBe(before.progressSamples);
+
+      yield* store.updateTask(id, { succeeded: value, failed: 3, description: "valid fields" });
+      const updated = Option.getOrThrow(yield* store.getTask(id));
+      expect(updated.units).toEqual({ succeeded: 2, failed: 3, processed: 5, total: 10 });
+      expect(updated.description).toBe("valid fields");
+    }).pipe(Effect.scoped),
+  );
+});
+
+test("rejects arithmetic overflow in individual counters and their sum", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const store = yield* makeProgressStore;
+      const id = yield* store.addTask({ description: "large counters" });
+      yield* store.updateTask(id, { succeeded: Number.MAX_VALUE });
+      const before = Option.getOrThrow(yield* store.getTask(id));
+      expect(before.units.processed).toBe(Number.MAX_VALUE);
+
+      yield* store.incrementSucceeded(id, Number.MAX_VALUE);
+      expect(Option.getOrThrow(yield* store.getTask(id)).units).toEqual(before.units);
+      yield* store.incrementFailed(id, Number.MAX_VALUE);
+      expect(Option.getOrThrow(yield* store.getTask(id)).units).toEqual(before.units);
+      yield* store.updateTask(id, { succeeded: Number.MAX_VALUE, failed: Number.MAX_VALUE });
+      const after = Option.getOrThrow(yield* store.getTask(id));
+      expect(after.units).toEqual(before.units);
+      expect(after.progressSamples).toBe(before.progressSamples);
+    }).pipe(Effect.scoped),
+  );
+});
+
+test("clamps finite negative counters while preserving finite overflow beyond total", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const store = yield* makeProgressStore;
+      const id = yield* store.addTask({ description: "finite counts", total: 2 });
+      yield* store.updateTask(id, { succeeded: -3, failed: 5 });
+      expect(Option.getOrThrow(yield* store.getTask(id)).units).toEqual({
+        succeeded: 0,
+        failed: 5,
+        processed: 5,
+        total: 2,
+      });
+      yield* store.incrementFailed(id, -10);
+      expect(Option.getOrThrow(yield* store.getTask(id)).units.processed).toBe(0);
+    }).pipe(Effect.scoped),
+  );
+});
+
+test.each(["missing", "removed"] as const)("normalizes a %s parent to a root", async (kind) => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const store = yield* makeProgressStore;
+      // The missing ID is also the next allocated ID, so it must not become a self-parent.
+      let parentId = TaskId(1);
+      if (kind === "removed") {
+        parentId = yield* store.addTask({
+          description: "removed parent",
+          transient: true,
+          countDisplay: "processedOnly",
+        });
+        yield* store.completeTask(parentId);
+      }
+      const id = yield* store.addTask({ description: "root", parentId });
+      const task = Option.getOrThrow(yield* store.getTask(id));
+      expect(task.parentId).toBeNull();
+      expect(task.transient).toBeFalse();
+      expect(task.countDisplay).toBe("detailed");
+      store.flush();
+      expect(store.getPublishedSnapshot().renderOrder).toEqual([{ id, depth: 0 }]);
+    }).pipe(Effect.scoped),
+  );
+});

--- a/tests/tasks/handle-reads.test.ts
+++ b/tests/tasks/handle-reads.test.ts
@@ -94,3 +94,43 @@ test("retained tasks remain readable after completion", async () => {
   expect(result.metadata).toEqual(Option.some(42));
   expect(Option.getOrThrow(result.snapshot).status).toBe("done");
 });
+
+test.each(["complete", "fail"] as const)("freezes all task fields after %s", async (finalize) => {
+  await Effect.runPromise(
+    withProgress(
+      Progress.task(
+        (handle) =>
+          Effect.gen(function* () {
+            yield* handle.incrementSucceeded(2);
+            yield* handle.incrementFailed(1);
+            yield* handle[finalize];
+            const before = Option.getOrThrow(yield* handle.getSnapshot);
+            let updaterCalled = false;
+
+            yield* handle.update({
+              description: "changed",
+              total: 50,
+              succeeded: 20,
+              failed: 10,
+              countDisplay: "processedOnly",
+            });
+            yield* handle.incrementSucceeded();
+            yield* handle.incrementFailed();
+            yield* handle.setMetadata(99);
+            yield* handle.updateMetadata((value) => {
+              updaterCalled = true;
+              return value + 1;
+            });
+            yield* handle.complete;
+            yield* handle.fail;
+
+            expect(Option.getOrThrow(yield* handle.getSnapshot)).toBe(before);
+            expect(yield* handle.getMetadata).toEqual(Option.some(42));
+            expect(updaterCalled).toBeFalse();
+            expect(before.status).toBe(finalize === "complete" ? "done" : "failed");
+          }),
+        { description: "finalized", metadata: 42, total: 5 },
+      ),
+    ),
+  );
+});


### PR DESCRIPTION
## Problem

Several mutation paths allow task state to disagree with its intended contract:

- Totals reject non-finite values, but counters accepted `NaN` and infinity, including arithmetic overflow from finite inputs.
- Finalization prevents another status transition, but later counter, field, and metadata updates still change retained completed/failed tasks.
- A missing parent ID is preserved in the task snapshot even though tree insertion displays it as a root. A caller can even supply the next allocated ID and create a self-parent reference.

## Solution

Enforce the rules at the store mutation boundary:

- Ignore all mutations of finalized or removed tasks before invoking the transform. This also prevents metadata updater callbacks, progress samples, timestamps, and publication state from changing after finalization.
- Preserve a counter's previous value when its proposed value is non-finite. Clamp finite negative values to zero, retaining the existing finite-overflow-beyond-total behavior.
- If the succeeded-plus-failed sum would overflow to infinity, retain both previous counters. Valid non-counter fields in an update can still change.
- Resolve the parent from current store state within task creation's atomic transition. Store `parentId: null` when that parent does not exist, so snapshot identity, inherited policies, and root render order agree.

Document these policies on the public contracts and in the README. Metadata objects are not deep-frozen; the terminal-state rule applies to task API mutations.

## Examples

### Invalid counters

Starting from succeeded=2 and failed=1, `incrementSucceeded(NaN)` preserves those counters. An update `{ succeeded: Infinity, failed: 3 }` preserves succeeded=2 and accepts failed=3. If two finite counters would sum to infinity, neither counter change is applied. Finite counts such as 5 processed against a total of 2 remain supported.

### Finalized handles

After `yield* handle.complete` or `yield* handle.fail`, later `update`, counter increments, metadata setters/updaters, and finalization calls do nothing. For retained tasks, `getSnapshot` and `getMetadata` still return `Some` with the final state. For transient tasks they return `None`, as established in the previous layer.

### Missing parents

A task created with a removed parent's ID becomes a root: `parentId` is null, render depth is zero, and it does not inherit the removed parent's transient or count-display settings. A valid existing parent retains the normal nesting behavior.

## Validation

- `bun test`: 146 passed, 0 failed, 444 assertions.
- `bun run check`: typecheck, lint, formatting, and Knip passed.
- `bun run format` applied; staged diff whitespace check passed.

New tests exercise NaN and both infinities, overflow of an individual counter and the combined sum, preserved finite overflow/negative clamping, missing and removed parents, self-parent prevention, and all handle mutations after both completion and failure. Existing tests retain coverage of finalization accounting, valid nesting, publication, and transient cleanup. Non-failing TSGO schema suggestions remain. No build or dev server was run.

## Compatibility and review

This intentionally stops post-finalization updates, rejects non-finite counter state, and normalizes missing parent references. Negative/non-finite total handling remains unchanged. Review `modifyTask` first for the terminal-state guard, then numeric normalization and parent creation. This is the top layer of the task-contract stack.

## Stack

GitHub stack #67: `main` → #64 (handle metadata API) → #65 (optional reads) → #66 (state invariants). Each PR is based on the layer below it. Manage the chain with `gh stack`.
