### PR TITLE
[1/5] Extract task lifecycle and typed handle construction

### DIFF
--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -1,12 +1,9 @@
 import type { TaskApi } from "../tasks/task-api";
 import type { TaskOperations } from "./task-operations";
-import { Context, Effect, Exit, Layer, Option } from "effect";
-import { adaptTaskApi } from "../tasks/task-api";
+import { Context, Effect, Layer, Option } from "effect";
+import { createTaskRunner } from "../tasks/run-task";
 import { ProgressStore } from "./store/store";
-import type { AddTaskOptions } from "../tasks/options";
-import type { TaskHandle } from "../tasks/task-handle";
-import type { TaskId } from "../task-model";
-import { Task } from "../tasks/current-task";
+import type { Task } from "../tasks/current-task";
 import { Renderer } from "../renderer/renderer";
 import { ProgressStdio } from "./stdio";
 
@@ -23,80 +20,13 @@ export interface ProgressService extends TaskOperations {
   readonly task: TaskApi<Task>;
 }
 
-interface CurrentParentState {
-  readonly owner: symbol;
-  readonly taskId: TaskId;
-}
-
 /** Builds the scoped implementation used by `ProgressService.task(...)` without auto-providing services. */
 const makeProgressService = Effect.gen(function* () {
   const inkRenderer = yield* Renderer;
   const store = yield* ProgressStore;
-  const parentOwner = Symbol();
-
-  // Each Progress service has its own task store, but they all share CurrentParent.
-  // Ignore parent IDs created by another service so tasks never point into the wrong store.
-  const currentParentId = Effect.map(CurrentParent, (cp) =>
-    Option.isSome(cp) && cp.value.owner === parentOwner
-      ? Option.some(cp.value.taskId)
-      : Option.none<TaskId>(),
-  );
+  const { addTask, task } = createTaskRunner(store);
 
   yield* inkRenderer.start;
-
-  const addTask = <M>(options: AddTaskOptions<M>) =>
-    Effect.gen(function* () {
-      const resolvedParentId =
-        options.parentId === undefined ? yield* currentParentId : Option.some(options.parentId);
-      return yield* store.addTask({
-        ...options,
-        parentId: Option.isSome(resolvedParentId) ? resolvedParentId.value : undefined,
-      });
-    });
-
-  const makeTaskHandle = <M>(taskId: TaskId): TaskHandle<M> => ({
-    id: taskId,
-    getMetadata: store.getTask(taskId).pipe(
-      Effect.map(
-        Option.map((task) => {
-          // SAFETY: This task was created with M; only its typed handle exposes metadata writes.
-          return task.metadata as M;
-        }),
-      ),
-    ),
-    setMetadata: (metadata) => store.setMetadata(taskId, metadata),
-    updateMetadata: (f) =>
-      store.updateMetadata(taskId, (current) =>
-        // SAFETY: The task handle reads the same metadata M established at task creation.
-        f(current as M),
-      ),
-    incrementSucceeded: (amount) => store.incrementSucceeded(taskId, amount),
-    incrementFailed: (amount) => store.incrementFailed(taskId, amount),
-    update: (options) => store.updateTask(taskId, options),
-    complete: store.completeTask(taskId),
-    fail: store.failTask(taskId),
-    getSnapshot: store.getTask(taskId),
-  });
-
-  const task = adaptTaskApi<Task>(
-    <M, A, E, R>(
-      callback: (handle: TaskHandle<M>) => Effect.Effect<A, E, R>,
-      options: AddTaskOptions<M>,
-    ) =>
-      Effect.gen(function* () {
-        const taskId = yield* addTask(options);
-        const handle = makeTaskHandle<M>(taskId);
-        const work = Effect.onExit(
-          Effect.suspend(() => callback(handle)),
-          // Explicit completion/failure wins because store finalization is terminal.
-          (exit) => (Exit.isSuccess(exit) ? store.completeTask(taskId) : store.failTask(taskId)),
-        );
-        return yield* work.pipe(
-          Effect.provideService(Task, taskId),
-          Effect.provideService(CurrentParent, Option.some({ owner: parentOwner, taskId })),
-        );
-      }),
-  );
 
   const service = {
     addTask,
@@ -129,11 +59,6 @@ const serviceOptionDefaultLayer = <I, S, E, R>(
       ),
     ),
   );
-
-const CurrentParent = Context.Reference<Option.Option<CurrentParentState>>(
-  "stromseng.dev/effective-progress/CurrentParent",
-  { defaultValue: Option.none },
-);
 
 export class Progress extends Context.Service<Progress, ProgressService>()(
   "stromseng.dev/effective-progress/Progress",

--- a/src/tasks/run-task.ts
+++ b/src/tasks/run-task.ts
@@ -1,0 +1,62 @@
+import { Context, Effect, Exit, Option } from "effect";
+import type { ProgressStoreService } from "../services/store/store";
+import type { TaskId } from "../task-model";
+import type { AddTaskOptions } from "./options";
+import { Task } from "./current-task";
+import { adaptTaskApi } from "./task-api";
+import { bindTaskHandle, type TaskHandle } from "./task-handle";
+
+interface CurrentParentState {
+  readonly owner: symbol;
+  readonly taskId: TaskId;
+}
+
+const CurrentParent = Context.Reference<Option.Option<CurrentParentState>>(
+  "stromseng.dev/effective-progress/CurrentParent",
+  { defaultValue: Option.none },
+);
+
+/** Owns parent inference and task execution for one Progress service instance. */
+export const createTaskRunner = (store: ProgressStoreService) => {
+  const parentOwner = Symbol();
+
+  // Each Progress service has its own task store, but they all share CurrentParent.
+  // Ignore parent IDs created by another service so tasks never point into the wrong store.
+  const currentParentId = Effect.map(CurrentParent, (cp) =>
+    Option.isSome(cp) && cp.value.owner === parentOwner
+      ? Option.some(cp.value.taskId)
+      : Option.none<TaskId>(),
+  );
+
+  const addTask = <M>(options: AddTaskOptions<M>) =>
+    Effect.gen(function* () {
+      const resolvedParentId =
+        options.parentId === undefined ? yield* currentParentId : Option.some(options.parentId);
+      return yield* store.addTask({
+        ...options,
+        parentId: Option.isSome(resolvedParentId) ? resolvedParentId.value : undefined,
+      });
+    });
+
+  const task = adaptTaskApi<Task>(
+    <M, A, E, R>(
+      callback: (handle: TaskHandle<M>) => Effect.Effect<A, E, R>,
+      options: AddTaskOptions<M>,
+    ) =>
+      Effect.gen(function* () {
+        const taskId = yield* addTask(options);
+        const handle = bindTaskHandle<M>(store, taskId);
+        const work = Effect.onExit(
+          Effect.suspend(() => callback(handle)),
+          // Explicit completion/failure wins because store finalization is terminal.
+          (exit) => (Exit.isSuccess(exit) ? store.completeTask(taskId) : store.failTask(taskId)),
+        );
+        return yield* work.pipe(
+          Effect.provideService(Task, taskId),
+          Effect.provideService(CurrentParent, Option.some({ owner: parentOwner, taskId })),
+        );
+      }),
+  );
+
+  return { addTask, task };
+};

--- a/src/tasks/task-handle.ts
+++ b/src/tasks/task-handle.ts
@@ -1,4 +1,5 @@
-import type { Effect, Option } from "effect";
+import type { ProgressStoreService } from "../services/store/store";
+import { Effect, Option } from "effect";
 import type { TaskId, TaskSnapshot } from "../task-model";
 import type { UpdateTaskOptions } from "./options";
 
@@ -31,3 +32,28 @@ export interface TaskHandle<M> {
   /** Reads the latest snapshot, or None if the task was removed. */
   readonly getSnapshot: Effect.Effect<Option.Option<TaskSnapshot>>;
 }
+
+/** Binds typed task-local operations to the task created with metadata M. */
+export const bindTaskHandle = <M>(store: ProgressStoreService, taskId: TaskId): TaskHandle<M> => ({
+  id: taskId,
+  getMetadata: store.getTask(taskId).pipe(
+    Effect.map(
+      Option.map((task) => {
+        // SAFETY: This task was created with M; only its typed handle exposes metadata writes.
+        return task.metadata as M;
+      }),
+    ),
+  ),
+  setMetadata: (metadata) => store.setMetadata(taskId, metadata),
+  updateMetadata: (f) =>
+    store.updateMetadata(taskId, (current) =>
+      // SAFETY: The task handle reads the same metadata M established at task creation.
+      f(current as M),
+    ),
+  incrementSucceeded: (amount) => store.incrementSucceeded(taskId, amount),
+  incrementFailed: (amount) => store.incrementFailed(taskId, amount),
+  update: (options) => store.updateTask(taskId, options),
+  complete: store.completeTask(taskId),
+  fail: store.failTask(taskId),
+  getSnapshot: store.getTask(taskId),
+});


### PR DESCRIPTION
Task lifecycle behavior was mixed with Progress service and renderer wiring. Move parent inference, per-service parent ownership, and exit-based finalization into `tasks/run-task.ts`; colocate typed handle construction with `TaskHandle`.

The Progress service remains the composition entry point. Nested task behavior, metadata typing, and explicit finalization precedence are preserved.

Stack 1/5. Base: `main`. Merge in order from 1 to 5.

Validation: `bun run check` (typecheck, lint, formatting, and Knip) and `bun test` (146 passing tests) at this layer.

Next: https://github.com/stromseng/effective-progress/pull/69
