### PR TITLE
[2/5] Make transient task cleanup an explicit state transition

### DIFF
--- a/src/services/store/store.ts
+++ b/src/services/store/store.ts
@@ -54,10 +54,28 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
     return publisher.publish(state, now);
   };
 
-  /** Mutates running tasks only, recording progress atomically. Undefined removes the task subtree. */
+  /** Replaces one task and records its processed-count observation in the same transition. */
+  const replaceTask = (
+    current: TaskStore,
+    task: TaskSnapshot,
+    nextTask: TaskSnapshot,
+    now: number,
+  ): TaskStore => {
+    if (nextTask === task) {
+      return current;
+    }
+    const tasks = new Map(current.tasks);
+    tasks.set(task.id, {
+      ...nextTask,
+      progressSamples: appendProgressSample(task.progressSamples, now, nextTask.units.processed),
+    });
+    return { ...current, tasks };
+  };
+
+  /** Mutates running tasks only, recording progress atomically. */
   const modifyTask = (
     taskId: TaskId,
-    transform: (task: TaskSnapshot, now: number) => TaskSnapshot | undefined,
+    transform: (task: TaskSnapshot, now: number) => TaskSnapshot,
   ) =>
     Effect.gen(function* () {
       const now = yield* Clock.currentTimeMillis;
@@ -66,23 +84,7 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
         if (!task || task.status !== "running") {
           return current;
         }
-        const nextTask = transform(task, now);
-        if (nextTask === task) {
-          return current;
-        }
-        const tasks = new Map(current.tasks);
-        if (nextTask === undefined) {
-          return { tasks, ...removeTransientSubtree(current, tasks, taskId) };
-        }
-        tasks.set(taskId, {
-          ...nextTask,
-          progressSamples: appendProgressSample(
-            task.progressSamples,
-            now,
-            nextTask.units.processed,
-          ),
-        });
-        return { ...current, tasks };
+        return replaceTask(current, task, transform(task, now), now);
       }, now);
     });
 
@@ -93,7 +95,19 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
     }));
 
   const finalizeTask = (taskId: TaskId, status: "done" | "failed") =>
-    modifyTask(taskId, (task, now) => finalizeTaskSnapshot(task, status, now));
+    Effect.gen(function* () {
+      const now = yield* Clock.currentTimeMillis;
+      yield* updateState((current) => {
+        const task = current.tasks.get(taskId);
+        if (!task || task.status !== "running") {
+          return current;
+        }
+        if (task.transient) {
+          return removeTransientSubtree(current, taskId);
+        }
+        return replaceTask(current, task, finalizeTaskSnapshot(task, status, now), now);
+      }, now);
+    });
 
   const store: ProgressStoreService = {
     getPublishedSnapshot: publisher.getPublishedSnapshot,

--- a/src/services/store/task-state.ts
+++ b/src/services/store/task-state.ts
@@ -121,17 +121,14 @@ export const createTaskSnapshot = <M>(
   return task;
 };
 
-/** Finalization is terminal; undefined requests removal of a transient subtree. */
+/** Finalizes retained task data; the store owns transient subtree removal. */
 export const finalizeTaskSnapshot = (
   task: TaskSnapshot,
   status: "done" | "failed",
   now: number,
-): TaskSnapshot | undefined => {
+): TaskSnapshot => {
   if (task.status !== "running") {
     return task;
-  }
-  if (task.transient) {
-    return undefined;
   }
   return {
     ...task,

--- a/src/services/store/task-tree.ts
+++ b/src/services/store/task-tree.ts
@@ -1,4 +1,4 @@
-import type { TaskId, TaskSnapshot } from "../../task-model";
+import type { TaskId } from "../../task-model";
 import type { TaskStore } from "./types";
 
 export const findInsertionIndex = (
@@ -39,30 +39,23 @@ const findSubtreeRange = (renderOrder: TaskStore["renderOrder"], taskId: TaskId)
   return { start, end };
 };
 
-export const removeTransientSubtree = (
-  current: TaskStore,
-  nextTasks: Map<TaskId, TaskSnapshot>,
-  taskId: TaskId,
-) => {
+/** Removes a task subtree from every state collection without mutating the current snapshot. */
+export const removeTransientSubtree = (current: TaskStore, taskId: TaskId): TaskStore => {
   const range = findSubtreeRange(current.renderOrder, taskId);
-  const removedTaskIds =
-    range === undefined
-      ? []
-      : current.renderOrder.slice(range.start, range.end).map((row) => row.id);
-  for (const removedTaskId of removedTaskIds) {
-    nextTasks.delete(removedTaskId);
+  if (range === undefined) {
+    return current;
   }
 
-  const nextColumns = new Map(current.columns);
-  for (const removedTaskId of removedTaskIds) {
-    nextColumns.delete(removedTaskId);
+  const tasks = new Map(current.tasks);
+  const columns = new Map(current.columns);
+  for (const row of current.renderOrder.slice(range.start, range.end)) {
+    tasks.delete(row.id);
+    columns.delete(row.id);
   }
 
   return {
-    renderOrder:
-      range === undefined
-        ? current.renderOrder
-        : current.renderOrder.toSpliced(range.start, range.end - range.start),
-    columns: nextColumns,
+    tasks,
+    renderOrder: current.renderOrder.toSpliced(range.start, range.end - range.start),
+    columns,
   };
 };

--- a/tests/store/state.test.ts
+++ b/tests/store/state.test.ts
@@ -193,6 +193,10 @@ describe("progress store state and publication", () => {
           columns,
         });
         store.flush();
+        const beforeRemoval = store.getPublishedSnapshot();
+        const originalTaskIds = [...beforeRemoval.tasks.keys()];
+        const originalOrder = [...beforeRemoval.renderOrder];
+        const originalColumns = [...beforeRemoval.columns.entries()];
 
         yield* store.completeTask(parentId);
         store.flush();
@@ -201,6 +205,9 @@ describe("progress store state and publication", () => {
         expect(publication.tasks.size).toBe(0);
         expect(publication.renderOrder).toEqual([]);
         expect(publication.columns.size).toBe(0);
+        expect([...beforeRemoval.tasks.keys()]).toEqual(originalTaskIds);
+        expect(beforeRemoval.renderOrder).toEqual(originalOrder);
+        expect([...beforeRemoval.columns.entries()]).toEqual(originalColumns);
       }).pipe(Effect.scoped),
     );
   });


### PR DESCRIPTION
Transient finalization previously returned `undefined` to trigger subtree deletion inside the general task mutation path. Make the store choose explicitly between removing a transient subtree and finalizing retained task data.

Subtree removal now returns a complete state without mutating caller-owned maps. Task replacement still records progress atomically. Extend the existing cleanup test to verify previously published snapshots remain unchanged.

Stack 2/5. Base: `refactor/task-lifecycle`. Merge in order from 1 to 5.

Validation: `bun run check` (typecheck, lint, formatting, and Knip) and `bun test` (146 passing tests) at this layer.

Previous: https://github.com/stromseng/effective-progress/pull/68 · Next: https://github.com/stromseng/effective-progress/pull/70
