### PR TITLE
[3/5] Clarify progress state and task ordering names

### DIFF
--- a/benchmarks/store-and-columns.ts
+++ b/benchmarks/store-and-columns.ts
@@ -5,7 +5,7 @@ import { prepareRows } from "../src/renderer/prepare-rows";
 import { ProgressStore } from "../src/services/store/store";
 import { TaskId, type TaskSnapshot } from "../src/task-model";
 import { type ColumnDef } from "../src/columns/types";
-import { type TaskStore } from "../src/services/store/types";
+import { type ProgressState } from "../src/services/store/types";
 
 const WARMUP_ROUNDS = 3;
 const MEASURED_ROUNDS = 9;
@@ -73,8 +73,8 @@ const makeColumnFixture = (rowCount: number, distinctPrepare: boolean) => {
     tasks: new Map<TaskId, TaskSnapshot>(),
     renderOrder: [],
     columns: new Map<TaskId, ReadonlyArray<ColumnDef<unknown, number>>>(),
-  } satisfies TaskStore;
-  const renderOrder: Array<TaskStore["renderOrder"][number]> = [];
+  } satisfies ProgressState;
+  const renderOrder: Array<ProgressState["renderOrder"][number]> = [];
 
   for (let index = 0; index < rowCount; index++) {
     const id = TaskId(index + 1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,12 @@ export {
 } from "./columns/types";
 export { type TaskHandle } from "./tasks/task-handle";
 export { type AddTaskOptions, type UpdateTaskOptions, type TrackOptions } from "./tasks/options";
-export { type RenderRow, type TaskStore } from "./services/store/types";
+export {
+  type TaskOrderEntry,
+  type ProgressState,
+  type RenderRow,
+  type TaskStore,
+} from "./services/store/types";
 export { type TaskOperations } from "./services/task-operations";
 export { Task } from "./tasks/current-task";
 export { type TaskApi } from "./tasks/task-api";

--- a/src/renderer/hooks/use-progress-render-view.ts
+++ b/src/renderer/hooks/use-progress-render-view.ts
@@ -1,15 +1,15 @@
 import { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import type { ProgressStoreService } from "../../services/store/store";
-import type { TaskStore } from "../../services/store/types";
+import type { ProgressState } from "../../services/store/types";
 import { prepareRows, type RenderSnapshot } from "../prepare-rows";
 
 interface ProgressRenderView {
-  readonly storeSnapshot: TaskStore;
+  readonly storeSnapshot: ProgressState;
   readonly renderSnapshot: RenderSnapshot;
   readonly hasRunningTasks: boolean;
 }
 
-const useRenderSnapshot = (storeSnapshot: TaskStore): RenderSnapshot => {
+const useRenderSnapshot = (storeSnapshot: ProgressState): RenderSnapshot => {
   const previousSnapshotRef = useRef<RenderSnapshot | undefined>(undefined);
 
   const renderSnapshot = useMemo(

--- a/src/renderer/prepare-rows.ts
+++ b/src/renderer/prepare-rows.ts
@@ -1,8 +1,8 @@
-import type { TaskStore } from "../services/store/types";
+import type { ProgressState } from "../services/store/types";
 import { textWidth } from "./shared/text-width";
 import type { OrderedTask, TaskRowModel } from "./row-model";
 
-const orderedVisibleTasks = (store: TaskStore): ReadonlyArray<OrderedTask> =>
+const orderedVisibleTasks = (store: ProgressState): ReadonlyArray<OrderedTask> =>
   store.renderOrder.flatMap((row) => {
     const snapshot = store.tasks.get(row.id);
     if (!snapshot || (snapshot.transient && snapshot.status !== "running")) {
@@ -77,7 +77,7 @@ const deriveRow = (
   };
 };
 
-const computeTreeInfo = (
+const buildTaskRows = (
   ordered: ReadonlyArray<OrderedTask>,
   previousRows: ReadonlyArray<TaskRowModel>,
 ): ReadonlyArray<TaskRowModel> => {
@@ -131,14 +131,14 @@ const computeTreeInfo = (
 };
 
 export const prepareRows = (
-  store: TaskStore,
+  store: ProgressState,
   previousSnapshot?: RenderSnapshot,
 ): RenderSnapshot => {
   const visibleTasks = orderedVisibleTasks(store);
   const hasRunningTasks = visibleTasks.some((entry) => entry.snapshot.status === "running");
 
   return {
-    rows: computeTreeInfo(visibleTasks, previousSnapshot?.rows ?? []),
+    rows: buildTaskRows(visibleTasks, previousSnapshot?.rows ?? []),
     hasRunningTasks,
   };
 };

--- a/src/services/store/snapshot-publisher.ts
+++ b/src/services/store/snapshot-publisher.ts
@@ -1,11 +1,11 @@
 import { Clock, Effect, Queue } from "effect";
-import type { TaskStore } from "./types";
+import type { ProgressState } from "./types";
 
 const SNAPSHOT_PUBLISH_INTERVAL_MILLIS = 100;
 
 /** Publishes the latest state at most every 100ms, with a synchronous shutdown flush. */
 export const createSnapshotPublisher = (
-  initialSnapshot: TaskStore,
+  initialSnapshot: ProgressState,
   publishQueue: Queue.Queue<void>,
 ) => {
   let pendingSnapshot = initialSnapshot;
@@ -74,7 +74,7 @@ export const createSnapshotPublisher = (
         publishNow(latestObservedAt);
       }
     },
-    publish: (snapshot: TaskStore, now: number): Effect.Effect<void> => {
+    publish: (snapshot: ProgressState, now: number): Effect.Effect<void> => {
       pendingSnapshot = snapshot;
       latestObservedAt = now;
       hasPendingPublish = true;

--- a/src/services/store/store.ts
+++ b/src/services/store/store.ts
@@ -2,21 +2,21 @@ import { appendProgressSample } from "../../progress-estimation";
 import { Clock, Context, Effect, Layer, Option, Queue } from "effect";
 import type { Column } from "../../columns/types";
 import type { TaskId } from "../../task-model";
-import type { TaskStore } from "./types";
+import type { ProgressState } from "./types";
 import type { TaskOperations } from "../task-operations";
 import { TaskId as makeTaskId, type TaskSnapshot } from "../../task-model";
 import {
   createTaskSnapshot,
   finalizeTaskSnapshot,
   normalizeUnits,
-  updatedSnapshot,
+  updateTaskSnapshot,
 } from "./task-state";
-import { findInsertionIndex, removeTransientSubtree } from "./task-tree";
+import { findChildInsertionPoint, removeTransientSubtree } from "./task-tree";
 import { createSnapshotPublisher } from "./snapshot-publisher";
 
 export interface ProgressStoreService extends TaskOperations {
   /** The renderer reads throttled snapshots; task operations read current state. */
-  readonly getPublishedSnapshot: () => TaskStore;
+  readonly getPublishedSnapshot: () => ProgressState;
   readonly subscribe: (listener: () => void) => () => void;
   readonly flush: () => void;
   /** Internal metadata operations are exposed publicly only through a typed task handle. */
@@ -34,7 +34,7 @@ interface ProgressStoreRuntime {
 
 const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStoreRuntime => {
   let nextTaskId = 0;
-  let state: TaskStore = {
+  let state: ProgressState = {
     tasks: new Map<TaskId, TaskSnapshot>(),
     renderOrder: [],
     columns: new Map<TaskId, ReadonlyArray<Column>>(),
@@ -42,7 +42,7 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
   const publisher = createSnapshotPublisher(state, publishQueue);
 
   const updateState = (
-    transform: (current: TaskStore) => TaskStore,
+    transform: (current: ProgressState) => ProgressState,
     now: number,
   ): Effect.Effect<void> => {
     const nextState = transform(state);
@@ -56,11 +56,11 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
 
   /** Replaces one task and records its processed-count observation in the same transition. */
   const replaceTask = (
-    current: TaskStore,
+    current: ProgressState,
     task: TaskSnapshot,
     nextTask: TaskSnapshot,
     now: number,
-  ): TaskStore => {
+  ): ProgressState => {
     if (nextTask === task) {
       return current;
     }
@@ -124,7 +124,7 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
           const task = createTaskSnapshot(taskId, options, parentSnapshot, now);
           const nextTasks = new Map(current.tasks);
           nextTasks.set(taskId, task);
-          const { index, depth } = findInsertionIndex(current.renderOrder, task.parentId);
+          const { index, depth } = findChildInsertionPoint(current.renderOrder, task.parentId);
           const nextRenderOrder = [...current.renderOrder];
           nextRenderOrder.splice(index, 0, { id: taskId, depth });
 
@@ -137,7 +137,8 @@ const makeProgressStoreRuntime = (publishQueue: Queue.Queue<void>): ProgressStor
 
         return taskId;
       }),
-    updateTask: (taskId, options) => modifyTask(taskId, (task) => updatedSnapshot(task, options)),
+    updateTask: (taskId, options) =>
+      modifyTask(taskId, (task) => updateTaskSnapshot(task, options)),
     incrementSucceeded: (taskId, amount = 1) => incrementCounter(taskId, "succeeded", amount),
     incrementFailed: (taskId, amount = 1) => incrementCounter(taskId, "failed", amount),
     completeTask: (taskId) => finalizeTask(taskId, "done"),

--- a/src/services/store/task-state.ts
+++ b/src/services/store/task-state.ts
@@ -65,7 +65,7 @@ const completedUnits = (units: TaskSnapshot["units"]): TaskSnapshot["units"] => 
 };
 
 /** Applies mutable task fields; the mutation boundary records progress samples. */
-export const updatedSnapshot = (snapshot: TaskSnapshot, options: UpdateTaskOptions) => {
+export const updateTaskSnapshot = (snapshot: TaskSnapshot, options: UpdateTaskOptions) => {
   const currentUnits = snapshot.units;
   const units =
     options.succeeded === undefined &&

--- a/src/services/store/task-tree.ts
+++ b/src/services/store/task-tree.ts
@@ -1,8 +1,8 @@
 import type { TaskId } from "../../task-model";
-import type { TaskStore } from "./types";
+import type { ProgressState } from "./types";
 
-export const findInsertionIndex = (
-  renderOrder: ReadonlyArray<TaskStore["renderOrder"][number]>,
+export const findChildInsertionPoint = (
+  renderOrder: ReadonlyArray<ProgressState["renderOrder"][number]>,
   parentId: TaskId | null,
 ) => {
   if (parentId === null) {
@@ -24,7 +24,7 @@ export const findInsertionIndex = (
 };
 
 /** Finds the half-open range containing a task and all of its descendants. */
-const findSubtreeRange = (renderOrder: TaskStore["renderOrder"], taskId: TaskId) => {
+const findSubtreeRange = (renderOrder: ProgressState["renderOrder"], taskId: TaskId) => {
   const start = renderOrder.findIndex((row) => row.id === taskId);
   if (start === -1) {
     return undefined;
@@ -40,7 +40,7 @@ const findSubtreeRange = (renderOrder: TaskStore["renderOrder"], taskId: TaskId)
 };
 
 /** Removes a task subtree from every state collection without mutating the current snapshot. */
-export const removeTransientSubtree = (current: TaskStore, taskId: TaskId): TaskStore => {
+export const removeTransientSubtree = (current: ProgressState, taskId: TaskId): ProgressState => {
   const range = findSubtreeRange(current.renderOrder, taskId);
   if (range === undefined) {
     return current;

--- a/src/services/store/types.ts
+++ b/src/services/store/types.ts
@@ -1,13 +1,19 @@
 import type { TaskId, TaskSnapshot } from "../../task-model";
 import type { Column } from "../../columns/types";
 
-export interface RenderRow {
+export interface TaskOrderEntry {
   readonly id: TaskId;
   readonly depth: number;
 }
 
-export interface TaskStore {
+export interface ProgressState {
   readonly tasks: ReadonlyMap<TaskId, TaskSnapshot>;
-  readonly renderOrder: ReadonlyArray<RenderRow>;
+  readonly renderOrder: ReadonlyArray<TaskOrderEntry>;
   readonly columns: ReadonlyMap<TaskId, ReadonlyArray<Column>>;
 }
+
+/** @deprecated Use TaskOrderEntry. */
+export type RenderRow = TaskOrderEntry;
+
+/** @deprecated Use ProgressState. */
+export type TaskStore = ProgressState;

--- a/tests/helpers/renderer.tsx
+++ b/tests/helpers/renderer.tsx
@@ -1,7 +1,7 @@
 import { renderToString } from "ink";
 import stripAnsi from "strip-ansi";
 import type { TaskSnapshot } from "../../src/task-model";
-import type { TaskStore } from "../../src/services/store/types";
+import type { ProgressState } from "../../src/services/store/types";
 import { TaskId } from "../../src/task-model";
 import { NowProvider } from "../../src/renderer/context/now-context";
 import { SpinnerProvider } from "../../src/renderer/context/spinner-context";
@@ -30,7 +30,7 @@ export const makeTaskSnapshot = (overrides: Partial<TaskSnapshot> = {}): TaskSna
 /** Exercise the real tree and width derivation instead of recreating it in fixtures. */
 export const makeRows = (
   tasks: ReadonlyArray<TaskSnapshot>,
-  renderOrder: TaskStore["renderOrder"] = tasks.map(({ id }) => ({ id, depth: 0 })),
+  renderOrder: ProgressState["renderOrder"] = tasks.map(({ id }) => ({ id, depth: 0 })),
 ): ReadonlyArray<TaskRowModel> =>
   prepareRows({
     tasks: new Map(tasks.map((task) => [task.id, task])),
@@ -47,7 +47,7 @@ export const renderRows = (
     now = 1_000,
     spinnerTick = 0,
   }: {
-    readonly columns?: TaskStore["columns"];
+    readonly columns?: ProgressState["columns"];
     readonly now?: number;
     readonly spinnerTick?: number;
   } = {},

--- a/tests/renderer/column-layout.test.tsx
+++ b/tests/renderer/column-layout.test.tsx
@@ -14,7 +14,7 @@ const makeTask = <M,>(
 
 const renderWithColumns = (
   rows: ReadonlyArray<TaskRowModel>,
-  columns: Progress.TaskStore["columns"],
+  columns: Progress.ProgressState["columns"],
   now = 1_000,
 ): string => renderRows(rows, { columns, now });
 

--- a/tests/renderer/prepare-rows.test.ts
+++ b/tests/renderer/prepare-rows.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { TaskId, type TaskSnapshot } from "../../src/task-model";
-import { type TaskStore } from "../../src/services/store/types";
+import { type ProgressState } from "../../src/services/store/types";
 import { prepareRows } from "../../src/renderer/prepare-rows";
 
 const makeTask = (id: number, description: string): TaskSnapshot => ({
@@ -17,7 +17,7 @@ const makeTask = (id: number, description: string): TaskSnapshot => ({
   metadata: undefined,
 });
 
-const makeStore = (entries: ReadonlyArray<readonly [TaskSnapshot, number]>): TaskStore => ({
+const makeStore = (entries: ReadonlyArray<readonly [TaskSnapshot, number]>): ProgressState => ({
   tasks: new Map(entries.map(([task]) => [task.id, task])),
   renderOrder: entries.map(([task, depth]) => ({ id: task.id, depth })),
   columns: new Map(),


### PR DESCRIPTION
Distinguish the `ProgressState` data object from the `ProgressStore` service, and name ID/depth ordering entries `TaskOrderEntry`. Rename task update, child insertion, and row construction functions to describe what they do.

Export the new public type names and retain `TaskStore` and `RenderRow` as deprecated aliases. Update internal consumers and benchmarks without changing behavior.

Stack 3/5. Base: `refactor/explicit-task-cleanup`. Merge in order from 1 to 5.

Validation: `bun run check` (typecheck, lint, formatting, and Knip) and `bun test` (146 passing tests) at this layer.

Previous: https://github.com/stromseng/effective-progress/pull/69 · Next: https://github.com/stromseng/effective-progress/pull/71
